### PR TITLE
chore: align Team X-Ray with Copilot SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Change Log
 
-All notable changes to the MCP Team X-Ray extension will be documented in this file.
+All notable changes to the Team X-Ray extension will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### 📖 Documentation
+- Clarified current positioning around Copilot SDK, GitHub Models fallback, and reduced local git fallback.
 
 ## [2.0.0] - 2026-03-12
 

--- a/README.md
+++ b/README.md
@@ -12,24 +12,25 @@ Transform your repository into a team expertise map. Discover who knows what, re
 - **🧠 Team Expertise Analysis** — AI-powered profiles with communication styles, specializations, and collaboration patterns
 - **📊 Management Insights** — Actionable recommendations: bus factor risks, growth opportunities, efficiency gaps
 - **🤖 GitHub Copilot SDK Integration** — Uses the Copilot SDK with custom tools for deep, context-aware analysis
+- **⚙️ Flexible AI Provider Settings** — Default `copilot`, optional `byok-openai`, `byok-anthropic`, `byok-azure`, or `github-models`
 - **🤖 Agent & Bot Detection** — Automatically identifies bot/agent contributors (Dependabot, Copilot, Renovate) with visual distinction
 - **📄 Dark-themed Reports** — Exportable HTML reports with SVG charts and an X-Ray visual identity
-- **⚡ Smart Fallback Chain** — Copilot SDK → BYOK (OpenAI/Anthropic/Azure) → GitHub Models API → Local-only analysis
+- **🛟 Git-Backed Fallback Analysis** — If AI analysis is unavailable, Team X-Ray can still assemble a reduced view from local git history
 
 ## How It Works
 
-Team X-Ray reads your git history — commits, contributors, file ownership — and feeds it to an AI agent through custom tools. The agent calls back into your repo data to build expertise profiles, identify risks, and generate management-ready insights.
+Team X-Ray reads your local git history — commits, contributors, file ownership — and feeds that data into the GitHub Copilot SDK when available. If Copilot is unavailable, it falls back to GitHub Models with your GitHub token; if AI output still fails, it produces a reduced git-based analysis.
 
 ![Team X-Ray Architecture](docs/architecture.png)
 
-### AI Provider Fallback
+### AI Provider Flow
 
-| Priority | Provider | Requirements |
-|----------|----------|-------------|
-| 1 | **GitHub Copilot SDK** | Copilot CLI installed + authenticated |
-| 2 | **BYOK** | Your own API key (OpenAI, Anthropic, or Azure) |
-| 3 | **GitHub Models API** | GitHub token with models access |
-| 4 | **Local-only** | No AI — git stats only |
+| Flow | Mode | Requirements |
+|------|------|--------------|
+| 1 | **Copilot SDK (`copilot`)** | Copilot CLI installed + authenticated; set `teamxray.cliPath` if the CLI is not on your PATH |
+| 2 | **BYOK via Copilot SDK** | `teamxray.aiProvider` = `byok-openai`, `byok-anthropic`, or `byok-azure`; run `Team X-Ray: Set BYOK API Key (Secure)`; set `teamxray.byokBaseUrl` |
+| 3 | **GitHub Models fallback** | Run `Team X-Ray: Set GitHub Token` |
+| 4 | **Reduced local fallback** | No extra setup; basic git-derived analysis only if AI output cannot be produced |
 
 ## Installation
 
@@ -43,13 +44,15 @@ Or [install from the VS Code Marketplace](https://marketplace.visualstudio.com/i
 
 ## Usage
 
-| Command | How |
-|---------|-----|
-| **Analyze Repository** | Command Palette → `Team X-Ray: Analyze Repository Expertise` |
-| **Find File Expert** | Right-click a file → `Team X-Ray: Find Expert for This File` |
-| **Team Overview** | Command Palette → `Team X-Ray: Show Team Expertise Overview` |
-| **Set API Key** | Command Palette → `Team X-Ray: Set GitHub Token` |
-| **Export Report** | Click export button in the analysis webview |
+| Command / Action | How |
+|------------------|-----|
+| `Team X-Ray: Analyze Repository Expertise` | Command Palette |
+| `Team X-Ray: Show Team Expertise Overview` | Command Palette |
+| `Team X-Ray: Analyze This File` | Command Palette |
+| `Team X-Ray: Find Expert for This File` | Right-click a file or open editor context menu |
+| `Team X-Ray: Set GitHub Token` | Command Palette |
+| `Team X-Ray: Set BYOK API Key (Secure)` | Command Palette |
+| Export report | Click the export button in the analysis webview |
 
 ## Documentation
 
@@ -57,7 +60,7 @@ Or [install from the VS Code Marketplace](https://marketplace.visualstudio.com/i
 |-----|-------------|
 | [Setup](docs/setup.md) | Installation & AI provider configuration |
 | [Architecture](docs/architecture.md) | Components, tools, worker threads, bot detection |
-| [AI Providers](docs/ai-providers.md) | Copilot SDK, BYOK, GitHub Models, local-only |
+| [AI Providers](docs/ai-providers.md) | Copilot SDK, BYOK provider overrides, GitHub Models, and reduced local fallback |
 | [Reports](docs/reports.md) | Webview, HTML export, dark X-Ray theme |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues & fixes |
 

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -1,72 +1,57 @@
 # AI Providers
 
-Team X-Ray supports four AI provider tiers. Each one activates automatically based on what's available.
+Team X-Ray analyzes local git data and then chooses the AI path that the current implementation supports. The main flow is Copilot SDK first, GitHub Models fallback second, with a reduced local fallback only if AI output cannot be produced.
+
+| Mode | Setting value | What it does | Requirements |
+|------|---------------|--------------|--------------|
+| Copilot SDK | `copilot` | Default analysis path with custom tools over local repo data | Copilot CLI installed + authenticated; set `teamxray.cliPath` if needed |
+| BYOK via Copilot SDK | `byok-openai`, `byok-anthropic`, `byok-azure` | Applies a provider override to the Copilot SDK session | Copilot CLI, `Team X-Ray: Set BYOK API Key (Secure)`, `teamxray.byokBaseUrl`, optional `teamxray.byokModel` |
+| GitHub Models fallback | `github-models` | Uses your GitHub token when Copilot is unavailable or analysis falls back | `Team X-Ray: Set GitHub Token` |
+| Reduced local fallback | — | Builds a basic git-derived analysis if AI output fails | No extra setup |
 
 ## Copilot SDK
 
-The primary provider. Uses GitHub Copilot's SDK with 5 custom tools that give the agent structured access to your repo data.
+This is the primary path. Team X-Ray dynamically loads `@github/copilot-sdk`, creates a `CopilotClient`, registers custom tools with `defineTool`, and sends repository data into a single analysis session.
 
-How it works:
-1. Team X-Ray imports `@anthropic-ai/sdk` dynamically via the Copilot SDK
-2. Registers tools with `defineTool` — each tool has a Zod schema defining its inputs/outputs
-3. The agent calls tools as needed during analysis, pulling contributor data, file experts, collaboration patterns
-4. Results come back as structured analysis with management insights
-
-**ESM bundling note:** The Copilot SDK uses ESM imports. To prevent webpack from bundling them (which breaks dynamic resolution), the import uses `/* webpackIgnore: true */`:
+**ESM bundling note:** the SDK is ESM-only, so the dynamic import must target `@github/copilot-sdk` directly:
 
 ```typescript
-const module = await import(/* webpackIgnore: true */ '@anthropic-ai/sdk');
+const sdk = await import(/* webpackIgnore: true */ '@github/copilot-sdk');
 ```
 
-## BYOK (Bring Your Own Key)
+If the CLI is installed outside your PATH, point the extension at it with `teamxray.cliPath`.
 
-Use your own API key with OpenAI, Anthropic, or Azure OpenAI.
+## BYOK provider overrides
 
-| Provider | Setting value | Models |
-|----------|--------------|--------|
-| OpenAI | `openai` | GPT-4o, GPT-4, GPT-3.5 Turbo |
-| Anthropic | `anthropic` | Claude 3.5 Sonnet, Claude 3 Opus/Haiku |
-| Azure OpenAI | `azure` | Your deployed models |
+BYOK settings are available, but in the current implementation they are applied through the Copilot SDK session rather than as a standalone non-Copilot path.
 
-Keys are stored in VS Code's [SecretStorage](https://code.visualstudio.com/api/references/vscode-api#SecretStorage) — encrypted per-machine, never written to settings files.
+Supported values:
+- `byok-openai`
+- `byok-anthropic`
+- `byok-azure`
 
-To set a key:
+Store the secret with:
 
 ```
-Command Palette → Team X-Ray: Set API Key
+Command Palette → Team X-Ray: Set BYOK API Key (Secure)
 ```
 
-Override the model with `teamxray.byokModel`. Set a custom endpoint (proxy, Azure deployment) with `teamxray.byokBaseUrl`.
+Also set:
+- `teamxray.byokBaseUrl` (required)
+- `teamxray.byokModel` (optional)
 
-## GitHub Models API
+## GitHub Models fallback
 
-Uses GitHub's hosted models API at `https://models.inference.ai.azure.com`.
+If the Copilot SDK is unavailable, Team X-Ray falls back to GitHub Models using your GitHub token.
 
-Requirements:
-- A GitHub token with `models: read` permission
-- Set `teamxray.aiProvider` to `github-models`
+Store the token with:
 
-## Local-Only Mode
+```
+Command Palette → Team X-Ray: Set GitHub Token
+```
 
-No AI provider needed. You get:
-- Commit counts per contributor
-- File ownership percentages
-- First and last activity dates
-- Contributor list with bot detection
+The current implementation calls `https://models.github.ai/inference/chat/completions`.
 
-You don't get:
-- Prose expertise profiles
-- Communication style analysis
-- Management insights (bus factor, growth opportunities, efficiency gaps)
-- Collaboration pattern narratives
+## Reduced local fallback
 
-## Fallback Behavior
-
-The fallback chain runs top-to-bottom. Each tier wraps its initialization in a try/catch:
-
-1. **Copilot SDK** — Checks if the CLI is installed and authenticated. If the import fails or auth is missing, moves on.
-2. **BYOK** — Checks SecretStorage for a key. If none found or the API returns an error, moves on.
-3. **GitHub Models** — Checks for a valid token. If the endpoint rejects the request, moves on.
-4. **Local-only** — Always succeeds. Returns raw git data without AI analysis.
-
-The user sees a notification indicating which provider was used.
+Team X-Ray does not currently expose a normal selectable "local-only" tier for the main analysis flow. Instead, it can assemble a reduced result from local git history when AI analysis cannot complete or the AI response cannot be parsed cleanly.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,7 +18,7 @@ Or search "Team X-Ray" in the Extensions sidebar.
 
 ## AI Provider Setup
 
-Team X-Ray uses a fallback chain — configure whichever tier you prefer and it handles the rest.
+Team X-Ray gathers local git data first, then runs AI analysis through the Copilot SDK when available. GitHub Models is the non-Copilot fallback, and a reduced local analysis is used only when AI output cannot be produced.
 
 ### Option 1: Copilot SDK (recommended)
 
@@ -29,37 +29,48 @@ curl -fsSL https://gh.io/copilot-install | bash
 copilot auth login
 ```
 
-Team X-Ray auto-detects the SDK. No configuration needed.
+Team X-Ray auto-detects the CLI. If it is not on your PATH, set `teamxray.cliPath` in VS Code settings.
 
-### Option 2: BYOK (Bring Your Own Key)
+Leave `teamxray.aiProvider` set to `copilot` (the default).
+
+### Option 2: BYOK through the Copilot SDK
 
 Open the Command Palette and run:
 
 ```
-Team X-Ray: Set API Key
+Team X-Ray: Set BYOK API Key (Secure)
 ```
 
 Enter your API key. It's stored in VS Code's SecretStorage (encrypted, per-machine).
 
-Supported providers:
-- **OpenAI** — GPT-4o, GPT-4, etc.
-- **Anthropic** — Claude 3.5, Claude 3, etc.
-- **Azure OpenAI** — Your Azure-hosted models
+Then configure:
+- `teamxray.aiProvider` = `byok-openai`, `byok-anthropic`, or `byok-azure`
+- `teamxray.byokBaseUrl` = your provider endpoint (required in the current implementation)
+- `teamxray.byokModel` = optional model override
 
-Set `teamxray.aiProvider` to `openai`, `anthropic`, or `azure` in VS Code settings.
+BYOK is currently wired through the Copilot SDK session, so the Copilot CLI still needs to be installed and authenticated.
 
-### Option 3: GitHub Models API
+### Option 3: GitHub Models fallback
 
-Requires a GitHub token with `models: read` permission. Set `teamxray.aiProvider` to `github-models`.
+Open the Command Palette and run:
 
-### Option 4: Local-only
+```
+Team X-Ray: Set GitHub Token
+```
 
-No AI, no setup. You get commit counts, file ownership percentages, activity dates, and contributor lists — but no prose analysis or management insights.
+Store a GitHub token with access to GitHub Models. If the Copilot SDK is unavailable, Team X-Ray uses that token to call GitHub Models.
+
+Set `teamxray.aiProvider` to `github-models` if you want settings to reflect the non-BYOK path.
+
+### Reduced local fallback
+
+There is no separate "local-only" provider to configure in the normal success path. If AI analysis cannot run or the response cannot be parsed, Team X-Ray can still assemble a reduced analysis from local git history.
 
 ## Settings
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `teamxray.aiProvider` | Provider to use: `copilot`, `openai`, `anthropic`, `azure`, `github-models` | `copilot` |
+| `teamxray.aiProvider` | Provider setting: `copilot`, `byok-openai`, `byok-anthropic`, `byok-azure`, `github-models` | `copilot` |
+| `teamxray.cliPath` | Path to the Copilot CLI executable when it is not available on your PATH | auto-detect |
 | `teamxray.byokModel` | Model override for BYOK providers (e.g. `gpt-4o`, `claude-3-5-sonnet-20241022`) | — |
 | `teamxray.byokBaseUrl` | Custom API endpoint for BYOK (useful for proxies or Azure deployments) | — |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,15 +2,15 @@
 
 ## "No AI provider available"
 
-The fallback chain couldn't find any configured provider. Your options:
+Team X-Ray could not start the Copilot SDK and did not have a GitHub token available for the GitHub Models fallback. Your options:
 
 1. Install and authenticate the Copilot CLI:
    ```bash
    curl -fsSL https://gh.io/copilot-install | bash
    copilot auth login
    ```
-2. Set an API key: Command Palette → `Team X-Ray: Set API Key`
-3. Use local-only mode — you'll get git stats without AI analysis
+2. If the CLI is installed outside your PATH, set `teamxray.cliPath` in VS Code settings.
+3. Run `Team X-Ray: Set GitHub Token` from the Command Palette.
 
 ## Copilot SDK Not Detected
 
@@ -27,7 +27,16 @@ copilot auth login
 copilot --version
 ```
 
-Restart VS Code after installing.
+If `copilot --version` works in a different shell but not from VS Code, set `teamxray.cliPath` to the full executable path and reload VS Code.
+
+## BYOK provider selected but not working
+
+In the current implementation, BYOK settings are applied through the Copilot SDK session. That means you still need a working Copilot CLI even when `teamxray.aiProvider` is set to `byok-openai`, `byok-anthropic`, or `byok-azure`.
+
+Also verify:
+- You ran `Team X-Ray: Set BYOK API Key (Secure)`
+- `teamxray.byokBaseUrl` is set
+- `teamxray.byokModel` is valid if you configured one
 
 ## Analysis Takes Too Long
 
@@ -43,7 +52,7 @@ What to expect:
 If you're contributing and see module resolution errors with the Copilot SDK, check that dynamic imports use the webpack ignore directive:
 
 ```typescript
-const module = await import(/* webpackIgnore: true */ '@anthropic-ai/sdk');
+const sdk = await import(/* webpackIgnore: true */ '@github/copilot-sdk');
 ```
 
 Without this, webpack tries to bundle the ESM module at build time and fails.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamxray",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamxray",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "teamxray",
   "displayName": "Team X-Ray",
   "description": "Human discovery through code analysis - reveal team expertise, communication styles, and hidden strengths using GitHub MCP integration",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "publisher": "AndreaGriffiths",
   "author": {
     "name": "alacolombiadev"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "teamxray",
   "displayName": "Team X-Ray",
-  "description": "Human discovery through code analysis - reveal team expertise, communication styles, and hidden strengths using GitHub MCP integration",
+  "description": "Human discovery through code analysis - reveal team expertise, communication styles, and hidden strengths using the Copilot SDK and git history",
   "version": "2.0.2",
   "publisher": "AndreaGriffiths",
   "author": {
@@ -29,7 +29,7 @@
     "team",
     "expertise",
     "github",
-    "mcp",
+    "git",
     "ai",
     "analysis",
     "collaboration",

--- a/src/core/expertise-analyzer.ts
+++ b/src/core/expertise-analyzer.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import axios from 'axios';
-import { CopilotMCPService } from './copilot-mcp-service';
+import { RepositoryActivityService } from './repository-activity-service';
 import { CopilotService } from './copilot-service';
 import { TokenManager } from './token-manager';
 import { GitService } from './git-service';
@@ -71,7 +71,7 @@ export interface GitHubSearchResponse {
 export class ExpertiseAnalyzer {
     private context: vscode.ExtensionContext;
     private outputChannel: vscode.OutputChannel;
-    private copilotMCPService: CopilotMCPService;
+    private repositoryActivityService: RepositoryActivityService;
     private copilotService: CopilotService | null;
     private tokenManager: TokenManager;
     private resourceManager: ResourceManager;
@@ -91,7 +91,7 @@ export class ExpertiseAnalyzer {
         this.tokenManager = tokenManager;
         this.copilotService = copilotService ?? null;
         this.outputChannel = vscode.window.createOutputChannel('Team Expertise Analysis');
-        this.copilotMCPService = new CopilotMCPService(this.outputChannel);
+        this.repositoryActivityService = new RepositoryActivityService(this.outputChannel);
         this.resourceManager = ResourceManager.getInstance();
 
         // Initialize utilities
@@ -795,17 +795,17 @@ Respond with JSON only (NO markdown, NO explanations):
                 }
             }
 
-            // Try MCP service
-            const repository = await this.copilotMCPService.detectRepository();
+            // Try repository activity service
+            const repository = await this.repositoryActivityService.detectRepository();
             if (repository) {
-                const fileExperts = await this.copilotMCPService.analyzeFileExperts(filePath, repository);
+                const fileExperts = await this.repositoryActivityService.analyzeFileExperts(filePath, repository);
                 if (fileExperts && fileExperts.length > 0) {
-                    this.outputChannel.appendLine(`✅ Found ${fileExperts.length} experts via MCP for file`);
+                    this.outputChannel.appendLine(`✅ Found ${fileExperts.length} experts from git history for file`);
                     return fileExperts;
                 }
             }
 
-            this.outputChannel.appendLine('⚡ MCP analysis unavailable, using local file analysis...');
+            this.outputChannel.appendLine('⚡ File-specific git history unavailable, using repository-wide fallback...');
             const fileData = await this.gatherFileData(filePath);
             if (!fileData) {
                 return null;

--- a/src/core/repository-activity-service.ts
+++ b/src/core/repository-activity-service.ts
@@ -20,7 +20,7 @@ export interface GitHubContributor {
 /**
  * GitHub repository detection and expert activity service.
  *
- * Previously handled Docker MCP server management and Copilot Chat queries.
+ * Previously handled broader repository integration and Copilot Chat queries.
  * Those responsibilities have moved to CopilotService (Copilot SDK integration).
  * This service now focuses on:
  *   - GitHub repository detection from git remotes
@@ -28,7 +28,7 @@ export interface GitHubContributor {
  *   - Expert activity display
  *   - Issue-to-expert matching
  */
-export class CopilotMCPService {
+export class RepositoryActivityService {
     private outputChannel: vscode.OutputChannel;
 
     constructor(outputChannel: vscode.OutputChannel) {
@@ -205,13 +205,7 @@ export class CopilotMCPService {
             if (!workspaceFolder) { return null; }
 
             const gitService = new GitService(workspaceFolder.uri.fsPath, this.outputChannel);
-            const relativePath = vscode.workspace.asRelativePath(filePath);
-            const commits = await gitService.getCommits(100);
-
-            // Filter commits that touch this file
-            const fileCommits = commits.filter(c =>
-                c.files.some((f: string) => f.includes(relativePath) || relativePath.includes(f))
-            );
+            const fileCommits = await gitService.getCommitsForFile(filePath, 100);
 
             if (fileCommits.length === 0) { return null; }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { CopilotService } from './core/copilot-service';
 import { Expert } from './types/expert';
 import { ExpertiseWebviewProvider } from './core/expertise-webview';
 import { ExpertiseTreeProvider } from './core/expertise-tree-provider';
-import { CopilotMCPService } from './core/copilot-mcp-service';
+import { RepositoryActivityService } from './core/repository-activity-service';
 import { TokenManager } from './core/token-manager';
 import { ErrorHandler } from './utils/error-handler';
 import { ResourceManager } from './utils/resource-manager';
@@ -230,32 +230,27 @@ Specializations: ${(expert.specializations || []).join(', ')}`;
         }
     });
 
-    // Helper function to get expert recent activity via MCP
+    // Helper function to get expert recent activity from local git history
     async function getExpertRecentActivity(expert: any) {
-        const token = await tokenManager.getToken();
-        if (!token) {
-            vscode.window.showWarningMessage('GitHub token is required to get expert activity. Run "Team XRay: Set Github Token" to provide one.');
-            return;
-        }
         const outputChannel = vscode.window.createOutputChannel('Team X-Ray Expert Activity');
 
         try {
-            const mcpService = new CopilotMCPService(outputChannel);
+            const repositoryActivityService = new RepositoryActivityService(outputChannel);
             
             vscode.window.withProgress({
                 location: vscode.ProgressLocation.Notification,
                 title: `Getting recent activity for ${expert.name}...`,
                 cancellable: false
             }, async (progress) => {
-                progress.report({ increment: 0, message: "Connecting to GitHub MCP..." });
+                progress.report({ increment: 0, message: "Reading local git history..." });
 
-                const result = await mcpService.getExpertRecentActivity(expert.email, expert.name);
+                const result = await repositoryActivityService.getExpertRecentActivity(expert.email, expert.name);
                 
                 if (result.success && result.activity) {
                     progress.report({ increment: 100, message: "Activity retrieved!" });
                     
-                    // Display the activity using the MCP service
-                    await mcpService.showExpertActivity(result.activity);
+                    // Display the activity using the repository activity service
+                    await repositoryActivityService.showExpertActivity(result.activity);
                     
                     vscode.window.showInformationMessage(`✅ Recent activity loaded for ${expert.name}`);
                 } else {
@@ -265,7 +260,7 @@ Specializations: ${(expert.specializations || []).join(', ')}`;
                     outputChannel.appendLine(`❌ Failed to get activity for ${expert.name}: ${result.error}`);
                     
                     vscode.window.showWarningMessage(
-                        `Could not get recent activity for ${expert.name}. ${result.error || 'Please check MCP configuration.'}`,
+                        `Could not get recent activity for ${expert.name}. ${result.error || 'Please check that the current workspace is a git repository.'}`,
                         'View Logs'
                     ).then(choice => {
                         if (choice === 'View Logs') {
@@ -299,11 +294,6 @@ Specializations: ${(expert.specializations || []).join(', ')}`;
     });
 
     const showExpertDetailsCommand = vscode.commands.registerCommand('teamxray.showExpertDetails', async (expert: any) => {
-        const token = await tokenManager.getToken();
-        if (!token) {
-            vscode.window.showWarningMessage('GitHub token is required to view expert details. Run "Team XRay: Set Github Token" to provide one.');
-            return;
-        }
         if (expert) {
             const message = `${expert.name}
 Email: ${expert.email}
@@ -359,7 +349,7 @@ Specializations: ${(expert.specializations || []).join(', ')}`;
     // const hasShownWelcome = context.globalState.get('teamxray.hasShownWelcome', false);
     // if (!hasShownWelcome) {
     //     vscode.window.showInformationMessage(
-    //         'Welcome to MCP Team X-Ray! Analyze your team\'s expertise to find the right experts for any code.',
+    //         'Welcome to Team X-Ray! Analyze your team\'s expertise to find the right experts for any code.',
     //         'Analyze Repository',
     //         'Learn More'
     //     ).then(choice => {

--- a/src/types/expert.ts
+++ b/src/types/expert.ts
@@ -209,7 +209,7 @@ export interface TokenValidationResult extends ValidationResult {
     rateLimitRemaining: number;
 }
 
-// MCP related types
+// Legacy response types
 export interface MCPResponse<T> {
     success: boolean;
     data?: T;


### PR DESCRIPTION
## Summary
- replace stale MCP positioning with Copilot SDK and git-backed analysis wording
- align provider/setup documentation with the current implementation
- rename the internal repository activity service to match its actual behavior

## Notes
- leaves public command IDs and settings unchanged for compatibility
- excludes unrelated local edits already present in the worktree

## Validation
- `npm run compile`
- `npm run lint` *(pre-existing warnings only)*
- `npm run test` *(fails because the repo has no `.vscode-test` config)*