### PR TITLE
feat: Progressive streaming rendering for webview analysis

### DIFF
--- a/src/core/__tests__/copilot-service.test.ts
+++ b/src/core/__tests__/copilot-service.test.ts
@@ -463,4 +463,133 @@ describe('CopilotService', () => {
             expect(result).toBeUndefined();
         });
     });
+
+    describe('analyzeTeamStreaming', () => {
+        it('streams chunks via onDelta callback and returns parsed analysis', async () => {
+            const data = makeRepoData();
+            const stats = makeStats();
+            const chunks: string[] = [];
+
+            // Mock session with event listeners
+            const eventListeners: Record<string, any[]> = {
+                'assistant.message': [],
+                'session.idle': [],
+            };
+
+            const mockSession = {
+                on: vi.fn((event: string, handler: any) => {
+                    if (!eventListeners[event]) {
+                        eventListeners[event] = [];
+                    }
+                    eventListeners[event].push(handler);
+                    return vi.fn(); // unsubscribe
+                }),
+                send: vi.fn(async () => {
+                    // Simulate streaming: emit assistant.message events then session.idle
+                    setTimeout(() => {
+                        eventListeners['assistant.message'].forEach(h => {
+                            h({
+                                data: { content: 'Chunk 1 ' },
+                                type: 'assistant.message',
+                            });
+                        });
+                    }, 10);
+                    setTimeout(() => {
+                        eventListeners['assistant.message'].forEach(h => {
+                            h({
+                                data: { content: 'Chunk 1 Chunk 2 ' },
+                                type: 'assistant.message',
+                            });
+                        });
+                    }, 20);
+                    setTimeout(() => {
+                        eventListeners['session.idle'].forEach(h => h());
+                    }, 30);
+                }),
+                abort: vi.fn(async () => {}),
+                destroy: vi.fn(async () => {}),
+            };
+
+            // Mock the createAnalysisSession to return our mock session
+            const privService = getPrivate(service);
+            privService.createAnalysisSession = vi.fn(async () => mockSession);
+            privService.parseAnalysisResponse = vi.fn(() => ({
+                experts: [
+                    {
+                        name: 'Alice',
+                        email: 'alice@test.com',
+                        expertise: 85,
+                        contributions: 30,
+                        specializations: ['TypeScript'],
+                        isBot: false,
+                    },
+                ],
+                riskFactors: [],
+                opportunities: [],
+            }));
+
+            // Initialize service (mock client)
+            privService.client = { createSession: vi.fn() };
+
+            // Run streaming analysis
+            const onDelta = vi.fn((chunk: string) => {
+                chunks.push(chunk);
+            });
+
+            const result = await service.analyzeTeamStreaming(data, stats, onDelta);
+
+            // Allow async event handlers to run
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            // Verify chunks were streamed
+            expect(onDelta).toHaveBeenCalled();
+            expect(chunks.length).toBeGreaterThan(0);
+            expect(chunks.join('')).toContain('Chunk');
+
+            // Verify analysis was returned
+            expect(result).toBeDefined();
+            expect(result.experts).toBeDefined();
+            expect(result.experts.length).toBe(1);
+            expect(result.experts[0].name).toBe('Alice');
+
+            // Verify session lifecycle
+            expect(mockSession.send).toHaveBeenCalled();
+            expect(mockSession.destroy).toHaveBeenCalled();
+        });
+
+        it('handles session timeout gracefully', async () => {
+            const data = makeRepoData();
+            const stats = makeStats();
+
+            // Mock session that times out
+            const mockSession = {
+                on: vi.fn(() => vi.fn()),
+                send: vi.fn(async () => {
+                    // Never emit session.idle to trigger timeout
+                }),
+                abort: vi.fn(async () => {}),
+                destroy: vi.fn(async () => {}),
+            };
+
+            const privService = getPrivate(service);
+            privService.createAnalysisSession = vi.fn(async () => mockSession);
+            privService.isSessionIdleTimeoutError = vi.fn(() => true);
+            privService.client = { createSession: vi.fn() };
+
+            // Reduce timeout for testing
+            privService.ANALYSIS_TIMEOUT_MS = 50;
+
+            const onDelta = vi.fn();
+
+            try {
+                await service.analyzeTeamStreaming(data, stats, onDelta);
+            } catch (error) {
+                // Timeout error is expected
+                expect(error).toBeDefined();
+            }
+
+            expect(mockSession.abort).toHaveBeenCalled();
+            expect(mockSession.destroy).toHaveBeenCalled();
+        });
+    });
 });

--- a/src/core/copilot-service.ts
+++ b/src/core/copilot-service.ts
@@ -217,8 +217,11 @@ export class CopilotService {
             try {
                 session.send({ prompt });
                 
-                // Wait for session to reach idle state
-                await this.waitForSessionIdle(session, this.ANALYSIS_TIMEOUT_MS);
+                await this.waitForSessionIdle(session, this.ANALYSIS_TIMEOUT_MS).catch((error: unknown) => {
+                    const message = error instanceof Error ? error.message : String(error);
+                    this.outputChannel.appendLine(`[CopilotService] Session idle wait failed: ${message}`);
+                    throw error;
+                });
 
                 if (!latestAssistantMessage) {
                     throw new Error('No response from Copilot agent');

--- a/src/core/copilot-service.ts
+++ b/src/core/copilot-service.ts
@@ -206,7 +206,7 @@ export class CopilotService {
             const unsubscribe = session.on('assistant.message', (event) => {
                 latestAssistantMessage = event;
                 if (event.data?.content) {
-                    onDelta(this.sanitizeStreamingDelta(event.data.content));
+                    onDelta(this.normalizeStreamingDelta(event.data.content));
                 }
             });
 
@@ -263,21 +263,15 @@ export class CopilotService {
         }
     }
 
-    private sanitizeStreamingDelta(content: unknown): string {
+    private normalizeStreamingDelta(content: unknown): string {
         if (typeof content !== 'string') {
             return '';
         }
 
-        return content.slice(0, 20_000).replace(/[&<>"'`=/]/g, (char) => ({
-            '&': '&amp;',
-            '<': '&lt;',
-            '>': '&gt;',
-            '"': '&quot;',
-            "'": '&#39;',
-            '`': '&#96;',
-            '=': '&#61;',
-            '/': '&#47;'
-        })[char] ?? '');
+        // The webview renders each delta via document.createTextNode, which never
+        // parses HTML. Raw text is therefore XSS-safe and shown literally; escaping
+        // here would double-encode the stream (e.g. "<" would display as "&lt;").
+        return content.slice(0, 20_000);
     }
 
     /**

--- a/src/core/copilot-service.ts
+++ b/src/core/copilot-service.ts
@@ -206,7 +206,7 @@ export class CopilotService {
             const unsubscribe = session.on('assistant.message', (event) => {
                 latestAssistantMessage = event;
                 if (event.data?.content) {
-                    onDelta(event.data.content);
+                    onDelta(this.sanitizeStreamingDelta(event.data.content));
                 }
             });
 
@@ -261,6 +261,23 @@ export class CopilotService {
         } finally {
             await session.destroy();
         }
+    }
+
+    private sanitizeStreamingDelta(content: unknown): string {
+        if (typeof content !== 'string') {
+            return '';
+        }
+
+        return content.slice(0, 20_000).replace(/[&<>"'`=/]/g, (char) => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+            '`': '&#96;',
+            '=': '&#61;',
+            '/': '&#47;'
+        })[char] ?? '');
     }
 
     /**

--- a/src/core/copilot-service.ts
+++ b/src/core/copilot-service.ts
@@ -182,6 +182,112 @@ export class CopilotService {
     }
 
     /**
+     * Run team expertise analysis with streaming — emits response chunks via onDelta
+     * callback and returns the final parsed analysis. Allows UI to show incremental
+     * progress while the agent is generating the response.
+     */
+    async analyzeTeamStreaming(
+        data: RepositoryData,
+        repoStats: RepositoryStats,
+        onDelta: (chunk: string) => void
+    ): Promise<ExpertiseAnalysis> {
+        if (!this.client) {
+            throw new Error('CopilotService is not initialized');
+        }
+
+        const tools = await this.buildTools(data, repoStats);
+        const session = await this.createAnalysisSession(tools);
+
+        try {
+            const prompt = this.buildAnalysisPrompt(data.repository, repoStats);
+            
+            let latestAssistantMessage: AssistantMessageEvent | undefined;
+
+            const unsubscribe = session.on('assistant.message', (event) => {
+                latestAssistantMessage = event;
+                if (event.data?.content) {
+                    onDelta(event.data.content);
+                }
+            });
+
+            const unsubscribeIdle = session.on('session.idle', () => {
+                // Session is idle; waitForSessionIdle will resolve
+            });
+
+            try {
+                session.send({ prompt });
+                
+                // Wait for session to reach idle state
+                await this.waitForSessionIdle(session, this.ANALYSIS_TIMEOUT_MS);
+
+                if (!latestAssistantMessage) {
+                    throw new Error('No response from Copilot agent');
+                }
+
+                return this.parseAnalysisResponse(latestAssistantMessage, data, repoStats);
+            } catch (error) {
+                if (!this.isSessionIdleTimeoutError(error)) {
+                    throw error;
+                }
+
+                this.outputChannel.appendLine(
+                    `[CopilotService] Team analysis timed out after ${Math.round(this.ANALYSIS_TIMEOUT_MS / 1000)}s. Attempting recovery...`
+                );
+
+                try {
+                    await session.abort();
+                } catch (abortError) {
+                    const abortMessage = abortError instanceof Error ? abortError.message : String(abortError);
+                    this.outputChannel.appendLine(
+                        `[CopilotService] Failed to abort timed-out session cleanly: ${abortMessage}`
+                    );
+                }
+
+                if (latestAssistantMessage) {
+                    this.outputChannel.appendLine(
+                        '[CopilotService] Recovered assistant response from timed-out session.'
+                    );
+                    return this.parseAnalysisResponse(latestAssistantMessage, data, repoStats);
+                }
+
+                throw error;
+            } finally {
+                unsubscribe();
+                unsubscribeIdle();
+            }
+        } finally {
+            await session.destroy();
+        }
+    }
+
+    /**
+     * Wait for session to reach idle state (analysis complete).
+     */
+    private async waitForSessionIdle(
+        session: CopilotSessionInstance,
+        timeoutMs: number
+    ): Promise<void> {
+        return new Promise((resolve, reject) => {
+            let settled = false;
+
+            const unsubscribeIdle = session.on('session.idle', () => {
+                if (settled) { return; }
+                settled = true;
+                clearTimeout(timer);
+                unsubscribeIdle();
+                resolve();
+            });
+
+            const timer = setTimeout(() => {
+                if (settled) { return; }
+                settled = true;
+                unsubscribeIdle();
+                reject(new Error(`waiting for session.idle (timeout after ${Math.round(timeoutMs / 1000)}s)`));
+            }, timeoutMs);
+        });
+    }
+
+    /**
      * Find experts for a specific file using the Copilot agent.
      */
     async analyzeFileExpert(

--- a/src/core/expertise-analyzer.ts
+++ b/src/core/expertise-analyzer.ts
@@ -91,8 +91,9 @@ export class ExpertiseAnalyzer {
     /**
      * Analyzes repository expertise using local git analysis and AI analysis
      * Now with smart data chunking for large repositories
+     * @param onDelta Optional callback to stream incremental analysis chunks to the UI
      */
-    async analyzeRepository(): Promise<ExpertiseAnalysis | null> {
+    async analyzeRepository(onDelta?: (chunk: string) => void): Promise<ExpertiseAnalysis | null> {
         return await ErrorHandler.withErrorHandling(async () => {
             this.outputChannel.show();
             this.outputChannel.appendLine('🚀 Starting repository expertise analysis...');
@@ -136,7 +137,7 @@ export class ExpertiseAnalyzer {
             }
 
             // Step 5: Perform AI analysis with chunking for large repos
-            const analysis = await this.performSmartAIAnalysis(repositoryData, repoStats);
+            const analysis = await this.performSmartAIAnalysis(repositoryData, repoStats, onDelta);
             if (!analysis) {
                 throw ErrorHandler.createError(
                     'ANALYSIS_FAILED',
@@ -378,13 +379,23 @@ export class ExpertiseAnalyzer {
      * Performs AI analysis with smart chunking and error handling.
      * Tries Copilot SDK first, then falls back to GitHub Models API.
      */
-    private async performSmartAIAnalysis(repositoryData: any, repoStats: RepositoryStats): Promise<ExpertiseAnalysis | null> {
+    private async performSmartAIAnalysis(
+        repositoryData: any,
+        repoStats: RepositoryStats,
+        onDelta?: (chunk: string) => void
+    ): Promise<ExpertiseAnalysis | null> {
         // Try Copilot SDK first
         if (this.copilotService?.isAvailable()) {
             try {
                 this.outputChannel.appendLine('🤖 Analyzing with Copilot SDK...');
                 const repoData = this.toRepositoryData(repositoryData, repoStats);
-                return await this.copilotService.analyzeTeam(repoData, repoStats);
+                
+                // Use streaming if callback provided, otherwise use standard method
+                if (onDelta) {
+                    return await this.copilotService.analyzeTeamStreaming(repoData, repoStats, onDelta);
+                } else {
+                    return await this.copilotService.analyzeTeam(repoData, repoStats);
+                }
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);
                 this.outputChannel.appendLine(`⚠️ Copilot SDK analysis failed, falling back to GitHub Models: ${message}`);

--- a/src/core/expertise-webview.ts
+++ b/src/core/expertise-webview.ts
@@ -888,27 +888,32 @@ export class ExpertiseWebviewProvider {
     <script nonce="${nonce}">
         const streamOutput = document.getElementById('streamOutput');
         const statusText = document.getElementById('statusText');
-        const sanitizeWebviewText = (value) => String(value ?? '').replace(/[&<>"']/g, (char) => ({
-            '&': '&amp;',
-            '<': '&lt;',
-            '>': '&gt;',
-            '"': '&quot;',
-            "'": '&#39;'
-        })[char]);
+        const sanitizeTextPayload = (value) => typeof value === 'string' ? value.slice(0, 20000) : '';
+        const appendTextOnly = (element, safeValue) => {
+            element.appendChild(document.createTextNode(safeValue));
+        };
+        const setTextOnly = (element, safeValue) => {
+            element.replaceChildren(document.createTextNode(safeValue));
+        };
 
         window.addEventListener('message', (event) => {
             const message = event.data;
+            if (!message || typeof message !== 'object') {
+                return;
+            }
             
             if (message.type === 'chunk') {
-                streamOutput.textContent += sanitizeWebviewText(message.content);
+                const safeContent = sanitizeTextPayload(message.content);
+                appendTextOnly(streamOutput, safeContent);
                 streamOutput.scrollTop = streamOutput.scrollHeight;
             } else if (message.type === 'status') {
-                statusText.textContent = sanitizeWebviewText(message.text);
+                const safeText = sanitizeTextPayload(message.text);
+                setTextOnly(statusText, safeText);
             } else if (message.type === 'error') {
-                const errorText = sanitizeWebviewText(message.text);
-                statusText.textContent = '❌ Error: ' + errorText;
+                const errorText = sanitizeTextPayload(message.text);
+                setTextOnly(statusText, '❌ Error: ' + errorText);
                 streamOutput.style.color = '#ef4444';
-                streamOutput.textContent += '\\n\\nAnalysis failed: ' + errorText;
+                appendTextOnly(streamOutput, '\\n\\nAnalysis failed: ' + errorText);
             }
         });
     </script>

--- a/src/core/expertise-webview.ts
+++ b/src/core/expertise-webview.ts
@@ -2,6 +2,14 @@ import * as vscode from 'vscode';
 import { Expert } from '../types/expert';
 import { ExpertiseAnalysis } from './expertise-analyzer';
 
+type WebviewCommand = 'showExpertDetails' | 'getExpertActivity' | 'openFile' | 'refreshAnalysis' | 'exportAnalysis';
+
+interface WebviewCommandMessage {
+    command: WebviewCommand;
+    expert?: Expert;
+    filePath?: string;
+}
+
 export class ExpertiseWebviewProvider {
     private context: vscode.ExtensionContext;
 
@@ -30,28 +38,72 @@ export class ExpertiseWebviewProvider {
 
         // Handle messages from the webview
         panel.webview.onDidReceiveMessage(
-            message => {
-                switch (message.command) {
-                    case 'showExpertDetails':
-                        this.showExpertDetails(message.expert);
-                        break;
-                    case 'getExpertActivity':
-                        this.getExpertActivity(message.expert);
-                        break;
-                    case 'openFile':
-                        this.openFile(message.filePath);
-                        break;
-                    case 'refreshAnalysis':
-                        vscode.commands.executeCommand('teamxray.analyzeRepository');
-                        break;
-                    case 'exportAnalysis':
-                        this.exportAnalysis();
-                        break;
-                }
-            },
+            (message: unknown) => this.handleWebviewMessage(message),
             undefined,
             this.context.subscriptions
         );
+    }
+
+    private handleWebviewMessage(message: unknown): void {
+        if (!this.isWebviewCommandMessage(message)) {
+            return;
+        }
+
+        switch (message.command) {
+            case 'showExpertDetails':
+                if (message.expert) {
+                    this.showExpertDetails(message.expert);
+                }
+                break;
+            case 'getExpertActivity':
+                if (message.expert) {
+                    this.getExpertActivity(message.expert);
+                }
+                break;
+            case 'openFile':
+                if (message.filePath) {
+                    this.openFile(message.filePath);
+                }
+                break;
+            case 'refreshAnalysis':
+                vscode.commands.executeCommand('teamxray.analyzeRepository');
+                break;
+            case 'exportAnalysis':
+                this.exportAnalysis();
+                break;
+        }
+    }
+
+    private isWebviewCommandMessage(message: unknown): message is WebviewCommandMessage {
+        if (!message || typeof message !== 'object') {
+            return false;
+        }
+
+        const candidate = message as { command?: unknown; expert?: unknown; filePath?: unknown };
+        const allowedCommands: WebviewCommand[] = [
+            'showExpertDetails',
+            'getExpertActivity',
+            'openFile',
+            'refreshAnalysis',
+            'exportAnalysis'
+        ];
+
+        if (typeof candidate.command !== 'string' || !allowedCommands.includes(candidate.command as WebviewCommand)) {
+            return false;
+        }
+
+        if (candidate.filePath !== undefined && typeof candidate.filePath !== 'string') {
+            return false;
+        }
+
+        if (
+            candidate.expert !== undefined &&
+            (!candidate.expert || typeof candidate.expert !== 'object')
+        ) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -761,25 +813,7 @@ export class ExpertiseWebviewProvider {
 
         // Re-register message handler for the final panel
         panel.webview.onDidReceiveMessage(
-            message => {
-                switch (message.command) {
-                    case 'showExpertDetails':
-                        this.showExpertDetails(message.expert);
-                        break;
-                    case 'getExpertActivity':
-                        this.getExpertActivity(message.expert);
-                        break;
-                    case 'openFile':
-                        this.openFile(message.filePath);
-                        break;
-                    case 'refreshAnalysis':
-                        vscode.commands.executeCommand('teamxray.analyzeRepository');
-                        break;
-                    case 'exportAnalysis':
-                        this.exportAnalysis();
-                        break;
-                }
-            },
+            (message: unknown) => this.handleWebviewMessage(message),
             undefined,
             this.context.subscriptions
         );
@@ -796,9 +830,9 @@ export class ExpertiseWebviewProvider {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}'; img-src ${cspSource}; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';">
     <title>Team X-Ray Streaming Analysis</title>
-    <style>
+    <style nonce="${nonce}">
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
@@ -888,11 +922,23 @@ export class ExpertiseWebviewProvider {
     <script nonce="${nonce}">
         const streamOutput = document.getElementById('streamOutput');
         const statusText = document.getElementById('statusText');
-        const sanitizeTextPayload = (value) => typeof value === 'string' ? value.slice(0, 20000) : '';
-        const appendTextOnly = (element, safeValue) => {
+        const escapeHtmlText = (value) => {
+            const text = typeof value === 'string' ? value.slice(0, 20000) : '';
+            return text.replace(/[&<>"'\`=/]/g, (char) => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+                '\`': '&#96;',
+                '=': '&#61;',
+                '/': '&#47;'
+            })[char]);
+        };
+        const appendSanitizedText = (element, safeValue) => {
             element.appendChild(document.createTextNode(safeValue));
         };
-        const setTextOnly = (element, safeValue) => {
+        const setSanitizedText = (element, safeValue) => {
             element.replaceChildren(document.createTextNode(safeValue));
         };
 
@@ -903,17 +949,17 @@ export class ExpertiseWebviewProvider {
             }
             
             if (message.type === 'chunk') {
-                const safeContent = sanitizeTextPayload(message.content);
-                appendTextOnly(streamOutput, safeContent);
+                const safeContent = escapeHtmlText(message.content);
+                appendSanitizedText(streamOutput, safeContent);
                 streamOutput.scrollTop = streamOutput.scrollHeight;
             } else if (message.type === 'status') {
-                const safeText = sanitizeTextPayload(message.text);
-                setTextOnly(statusText, safeText);
+                const safeText = escapeHtmlText(message.text);
+                setSanitizedText(statusText, safeText);
             } else if (message.type === 'error') {
-                const errorText = sanitizeTextPayload(message.text);
-                setTextOnly(statusText, '❌ Error: ' + errorText);
+                const errorText = escapeHtmlText(message.text);
+                setSanitizedText(statusText, '❌ Error: ' + errorText);
                 streamOutput.style.color = '#ef4444';
-                appendTextOnly(streamOutput, '\\n\\nAnalysis failed: ' + errorText);
+                appendSanitizedText(streamOutput, '\\n\\nAnalysis failed: ' + errorText);
             }
         });
     </script>

--- a/src/core/expertise-webview.ts
+++ b/src/core/expertise-webview.ts
@@ -888,19 +888,27 @@ export class ExpertiseWebviewProvider {
     <script nonce="${nonce}">
         const streamOutput = document.getElementById('streamOutput');
         const statusText = document.getElementById('statusText');
+        const sanitizeWebviewText = (value) => String(value ?? '').replace(/[&<>"']/g, (char) => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        })[char]);
 
         window.addEventListener('message', (event) => {
             const message = event.data;
             
             if (message.type === 'chunk') {
-                streamOutput.textContent += message.content;
+                streamOutput.textContent += sanitizeWebviewText(message.content);
                 streamOutput.scrollTop = streamOutput.scrollHeight;
             } else if (message.type === 'status') {
-                statusText.textContent = message.text;
+                statusText.textContent = sanitizeWebviewText(message.text);
             } else if (message.type === 'error') {
-                statusText.textContent = '❌ Error: ' + message.text;
+                const errorText = sanitizeWebviewText(message.text);
+                statusText.textContent = '❌ Error: ' + errorText;
                 streamOutput.style.color = '#ef4444';
-                streamOutput.textContent += '\\n\\nAnalysis failed: ' + message.text;
+                streamOutput.textContent += '\\n\\nAnalysis failed: ' + errorText;
             }
         });
     </script>

--- a/src/core/expertise-webview.ts
+++ b/src/core/expertise-webview.ts
@@ -730,6 +730,185 @@ export class ExpertiseWebviewProvider {
     }
 
     /**
+     * Creates and shows a streaming webview panel with skeleton HTML.
+     * Returns the panel so the caller can stream chunks to it and later update with final analysis.
+     */
+    public createStreamingPanel(repositoryName: string): vscode.WebviewPanel {
+        const panel = vscode.window.createWebviewPanel(
+            'teamxray.streaming',
+            `Team X-Ray Analysis — ${repositoryName}`,
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true
+            }
+        );
+
+        panel.webview.html = this.getStreamingSkeleton(panel.webview.cspSource, repositoryName);
+
+        return panel;
+    }
+
+    /**
+     * Updates a streaming panel with the final analysis HTML.
+     * Call this when the analysis is complete to replace the skeleton with the full report.
+     */
+    public updatePanelWithAnalysis(panel: vscode.WebviewPanel, analysis: ExpertiseAnalysis): void {
+        panel.webview.html = this.getWebviewContent(analysis, panel.webview.cspSource);
+        
+        // Store analysis for export functionality
+        this.setCurrentAnalysis(analysis);
+
+        // Re-register message handler for the final panel
+        panel.webview.onDidReceiveMessage(
+            message => {
+                switch (message.command) {
+                    case 'showExpertDetails':
+                        this.showExpertDetails(message.expert);
+                        break;
+                    case 'getExpertActivity':
+                        this.getExpertActivity(message.expert);
+                        break;
+                    case 'openFile':
+                        this.openFile(message.filePath);
+                        break;
+                    case 'refreshAnalysis':
+                        vscode.commands.executeCommand('teamxray.analyzeRepository');
+                        break;
+                    case 'exportAnalysis':
+                        this.exportAnalysis();
+                        break;
+                }
+            },
+            undefined,
+            this.context.subscriptions
+        );
+    }
+
+    /**
+     * Generates lightweight skeleton HTML for streaming analysis.
+     * Shows a header and a stream output area that the extension populates via postMessage.
+     */
+    private getStreamingSkeleton(cspSource: string, repositoryName: string): string {
+        const nonce = this.generateNonce();
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
+    <title>Team X-Ray Streaming Analysis</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+            font-size: 14px;
+            line-height: 1.6;
+            color: #e2e8f0;
+            background: #0a0a0f;
+            padding: 0;
+            margin: 0;
+            min-height: 100vh;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 32px 24px;
+        }
+        .header {
+            background: #0a0a0f;
+            padding: 48px 40px;
+            border: 1px solid #1e293b;
+            border-radius: 12px;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .header h1 {
+            font-size: 32px;
+            font-weight: 700;
+            margin-bottom: 16px;
+            color: #06b6d4;
+        }
+        .header p {
+            font-size: 16px;
+            color: #94a3b8;
+        }
+        .stream-area {
+            background: #0f172a;
+            border: 1px solid #1e293b;
+            border-radius: 8px;
+            padding: 20px;
+            font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+            font-size: 12px;
+            color: #22c55e;
+            overflow-y: auto;
+            max-height: 600px;
+            line-height: 1.5;
+            white-space: pre-wrap;
+            word-break: break-word;
+            position: relative;
+            min-height: 200px;
+        }
+        .spinner {
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            border: 2px solid #1e293b;
+            border-top-color: #06b6d4;
+            border-radius: 50%;
+            animation: spin 0.6s linear infinite;
+            margin-left: 8px;
+        }
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+        .status {
+            color: #94a3b8;
+            font-size: 12px;
+            margin-top: 12px;
+            display: flex;
+            align-items: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🔬 Team X-Ray</h1>
+            <p>Analyzing repository: <strong>${this.escapeHtmlAttribute(repositoryName)}</strong></p>
+        </div>
+
+        <div class="stream-area" id="streamOutput"></div>
+        <div class="status">
+            <span id="statusText">Initializing analysis</span>
+            <span class="spinner"></span>
+        </div>
+    </div>
+
+    <script nonce="${nonce}">
+        const streamOutput = document.getElementById('streamOutput');
+        const statusText = document.getElementById('statusText');
+
+        window.addEventListener('message', (event) => {
+            const message = event.data;
+            
+            if (message.type === 'chunk') {
+                streamOutput.textContent += message.content;
+                streamOutput.scrollTop = streamOutput.scrollHeight;
+            } else if (message.type === 'status') {
+                statusText.textContent = message.text;
+            } else if (message.type === 'error') {
+                statusText.textContent = '❌ Error: ' + message.text;
+                streamOutput.style.color = '#ef4444';
+                streamOutput.textContent += '\\n\\nAnalysis failed: ' + message.text;
+            }
+        });
+    </script>
+</body>
+</html>`;
+    }
+
+    /**
      * Generates the HTML content for the webview
      */
     private getWebviewContent(analysis: ExpertiseAnalysis, cspSource: string): string {

--- a/src/core/expertise-webview.ts
+++ b/src/core/expertise-webview.ts
@@ -922,24 +922,15 @@ export class ExpertiseWebviewProvider {
     <script nonce="${nonce}">
         const streamOutput = document.getElementById('streamOutput');
         const statusText = document.getElementById('statusText');
-        const escapeHtmlText = (value) => {
-            const text = typeof value === 'string' ? value.slice(0, 20000) : '';
-            return text.replace(/[&<>"'\`=/]/g, (char) => ({
-                '&': '&amp;',
-                '<': '&lt;',
-                '>': '&gt;',
-                '"': '&quot;',
-                "'": '&#39;',
-                '\`': '&#96;',
-                '=': '&#61;',
-                '/': '&#47;'
-            })[char]);
+        // createTextNode never parses HTML, so raw text is XSS-safe and shown
+        // literally. Only bound the length here; escaping would double-encode the
+        // stream because the server already normalized it (e.g. "<" -> "&amp;lt;").
+        const toDisplayText = (value) => (typeof value === 'string' ? value.slice(0, 20000) : '');
+        const appendStreamText = (element, value) => {
+            element.appendChild(document.createTextNode(toDisplayText(value)));
         };
-        const appendSanitizedText = (element, safeValue) => {
-            element.appendChild(document.createTextNode(safeValue));
-        };
-        const setSanitizedText = (element, safeValue) => {
-            element.replaceChildren(document.createTextNode(safeValue));
+        const setStreamText = (element, value) => {
+            element.replaceChildren(document.createTextNode(toDisplayText(value)));
         };
 
         window.addEventListener('message', (event) => {
@@ -949,17 +940,15 @@ export class ExpertiseWebviewProvider {
             }
             
             if (message.type === 'chunk') {
-                const safeContent = escapeHtmlText(message.content);
-                appendSanitizedText(streamOutput, safeContent);
+                appendStreamText(streamOutput, message.content);
                 streamOutput.scrollTop = streamOutput.scrollHeight;
             } else if (message.type === 'status') {
-                const safeText = escapeHtmlText(message.text);
-                setSanitizedText(statusText, safeText);
+                setStreamText(statusText, message.text);
             } else if (message.type === 'error') {
-                const errorText = escapeHtmlText(message.text);
-                setSanitizedText(statusText, '❌ Error: ' + errorText);
+                const errorText = toDisplayText(message.text);
+                setStreamText(statusText, '❌ Error: ' + errorText);
                 streamOutput.style.color = '#ef4444';
-                appendSanitizedText(streamOutput, '\\n\\nAnalysis failed: ' + errorText);
+                appendStreamText(streamOutput, '\\n\\nAnalysis failed: ' + errorText);
             }
         });
     </script>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -170,17 +170,52 @@ export function activate(context: vscode.ExtensionContext) {
                 return;
             }
             
-            await resourceManager.withProgress("Analyzing repository expertise...", async (progress) => {
-                progress.report({ increment: 0, message: "Starting analysis..." });
-                const analysis = await analyzer.analyzeRepository();
+            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+            const repoName = workspaceFolder?.name ?? 'Unknown Repository';
+
+            // Create streaming panel immediately
+            const streamingPanel = webviewProvider.createStreamingPanel(repoName);
+
+            const streamCallback = (chunk: string) => {
+                streamingPanel.webview.postMessage({
+                    type: 'chunk',
+                    content: chunk
+                });
+            };
+
+            const statusCallback = (status: string) => {
+                streamingPanel.webview.postMessage({
+                    type: 'status',
+                    text: status
+                });
+            };
+
+            try {
+                statusCallback('Analyzing repository...');
+                const analysis = await analyzer.analyzeRepository(streamCallback);
+
                 if (analysis) {
-                    progress.report({ increment: 50, message: "Generating report..." });
+                    statusCallback('Generating report...');
                     await analyzer.saveAnalysis(analysis);
                     treeProvider.refresh(analysis);
-                    progress.report({ increment: 100, message: "Complete!" });
-                    webviewProvider.showAnalysisResults(analysis);
+
+                    // Update the panel with final analysis HTML
+                    webviewProvider.updatePanelWithAnalysis(streamingPanel, analysis);
+                    
+                    statusCallback('Complete!');
+                } else {
+                    streamingPanel.webview.postMessage({
+                        type: 'error',
+                        text: 'Analysis returned no results'
+                    });
                 }
-            });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                streamingPanel.webview.postMessage({
+                    type: 'error',
+                    text: message
+                });
+            }
         }, 'analyze repository');
     });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { Validator } from './utils/validation';
 
 // Module-level reference for cleanup in deactivate()
 let copilotService: CopilotService | undefined;
+const ANALYSIS_COMMAND_TIMEOUT_MS = 330_000;
 
 // This method is called when the extension is activated
 // extension is activated the very first time the command is executed
@@ -162,6 +163,25 @@ export function activate(context: vscode.ExtensionContext) {
         }
         return true;
     }
+
+    function withAnalysisTimeout<T>(operation: Promise<T>): Promise<T> {
+        return new Promise<T>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                reject(new Error(`Repository analysis timed out after ${Math.round(ANALYSIS_COMMAND_TIMEOUT_MS / 1000)}s`));
+            }, ANALYSIS_COMMAND_TIMEOUT_MS);
+
+            operation.then(
+                value => {
+                    clearTimeout(timer);
+                    resolve(value);
+                },
+                error => {
+                    clearTimeout(timer);
+                    reject(error);
+                }
+            );
+        });
+    }
     
     // Register main analysis command
     const analyzeRepositoryCommand = vscode.commands.registerCommand('teamxray.analyzeRepository', async () => {
@@ -192,7 +212,7 @@ export function activate(context: vscode.ExtensionContext) {
 
             try {
                 statusCallback('Analyzing repository...');
-                const analysis = await analyzer.analyzeRepository(streamCallback);
+                const analysis = await withAnalysisTimeout(analyzer.analyzeRepository(streamCallback));
 
                 if (analysis) {
                     statusCallback('Generating report...');


### PR DESCRIPTION
## Problem
When analyzing large repositories, users see a ~2-minute blank screen while waiting for the full AI response. This creates a poor UX and uncertainty about whether the analysis is actually running.

## Solution
Implemented progressive (streaming) rendering that displays analysis chunks as they're generated by the AI model, eliminating the blank screen wait.

### Architecture
- **CopilotService**: New `analyzeTeamStreaming()` method uses `session.on('assistant.message')` to capture incremental content chunks from the SDK; awaits `session.idle` with timeout recovery
- **ExpertiseWebview**: New `createStreamingPanel()` displays a lightweight skeleton (monospace pre + spinner) immediately; `updatePanelWithAnalysis()` replaces it with the final report
- **ExpertiseAnalyzer**: Routes to streaming path when an `onDelta` callback is provided; falls back to synchronous `analyzeTeam()` otherwise
- **Extension**: Command handler creates skeleton panel, passes the stream callback, and swaps in the final analysis when complete

### User Experience
**Before**: Blank screen for ~2 minutes, then sudden full report
**After**: Skeleton appears instantly, chunks stream in real-time, final report replaces skeleton

### Testing
- Webpack compiles (`npm run compile`)
- TypeScript compiles (`npm run compile-tests`)
- 2 new streaming tests pass (chunk delivery + timeout recovery)

### Files Changed
- `src/core/copilot-service.ts`: `analyzeTeamStreaming()` + `waitForSessionIdle()`
- `src/core/expertise-webview.ts`: streaming panel helpers
- `src/core/expertise-analyzer.ts`: callback routing
- `src/extension.ts`: command integration
- `src/core/__tests__/copilot-service.test.ts`: streaming test suite

> Note: Manual validation in the VS Code Extension Host (F5) is still recommended to confirm chunks stream live in the real webview.