### PR TITLE
fix: patch serialize-javascript ReDoS (Dependabot could not auto-bump via mocha)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8084,16 +8084,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -8713,13 +8703,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-cookie-parser": {

--- a/package.json
+++ b/package.json
@@ -204,6 +204,9 @@
     "webpack": "^5.105.0",
     "webpack-cli": "^6.0.1"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
+  },
   "dependencies": {
     "@github/copilot-sdk": "^0.1.32",
     "axios": "1.16.0",


### PR DESCRIPTION
## Summary

- Adds a single npm override for `serialize-javascript` to `^7.0.5`.
- Updates `package-lock.json`, resolving `serialize-javascript` to `7.0.7`.
- Does not add overrides for `form-data`, `undici`, `markdown-it`, `vite`, or `js-yaml` because those are covered by existing Dependabot PRs #53, #55, #52, #51, and #54.

## Why this is safe

`mocha` pins `serialize-javascript` to `^6.0.2`, but the security fix is in `7.0.5`. The 6 to 7 major change adds `engines.node >=20`, and this project already requires Node 20, so the override is safe for this repo.

## Validation

- `npm run compile` succeeds.
- `npx vitest run src/core/__tests__/copilot-service.test.ts` has no new failures compared with `origin/main`: both report 9 failed and 15 passed.
- `npm audit` count changed from 14 to 11.