### PR TITLE
fix: replace retired Marketplace badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-07-16
+
+### 🐛 Bug Fixes
+- Replaced the retired Shields.io Visual Studio Marketplace badge with a working Marketplace version badge.
+
 ## [2.1.0] - 2026-07-16
 
 ### ✨ Features

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Transform your repository into a team expertise map. Discover who knows what, reveal hidden collaboration patterns, and get AI-powered management insights — all from your git history.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/AndreaGriffiths.teamxray?color=blue&label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=AndreaGriffiths.teamxray)
+[![VS Marketplace version](https://vsmarketplacebadges.dev/version-short/AndreaGriffiths.teamxray.svg)](https://marketplace.visualstudio.com/items?itemName=AndreaGriffiths.teamxray)
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamxray",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamxray",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "teamxray",
   "displayName": "Team X-Ray",
   "description": "Human discovery through code analysis - reveal team expertise, communication styles, and hidden strengths using the Copilot SDK and git history",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "publisher": "AndreaGriffiths",
   "author": {
     "name": "alacolombiadev"


### PR DESCRIPTION
## Summary
- replace the retired Shields.io Visual Studio Marketplace badge
- use the working Marketplace version badge
- release 2.1.1 so the Marketplace-embedded README is refreshed

## Validation
- `npm test`
- `npm audit --omit=dev --audit-level critical`
- packaged `teamxray-2.1.1-marketplace.vsix`