### PR TITLE
Trailer-aware agent detection + single-snapshot analysis pipeline

### DIFF
--- a/PLAN-AGENT-DETECTION-AND-PERFORMANCE.md
+++ b/PLAN-AGENT-DETECTION-AND-PERFORMANCE.md
@@ -214,14 +214,14 @@ Add duration logging around each phase (`snapshot`, `sampling`, `ai`, `render`) 
 
 ---
 
-## Suggested rollout
+## Rollout status
 
-| Phase | Scope | Size |
+| Phase | Scope | Status |
 |---|---|---|
-| 1 | P1 + P2 + P7 (single snapshot, parallel, timings) — pure refactor, no behavior change | S |
-| 2 | §1.1 + §1.2 + §1.3 + §1.7 (trailer fetch, classification, identity table, tests) + P6 | M |
-| 3 | P3 + P4 + P5 (in-memory contributors, HEAD cache, bot-aware sampling) | M |
-| 4 | §1.4 + §1.5 (config patterns, AI-attribution metrics & UI) | M |
-| 5 | §1.6 (checkpoint session integration) + Part 3 items | S–M |
+| 1 | P1 + P2 + P7 (single snapshot, parallel, timings) — pure refactor, no behavior change | ✅ Done |
+| 2 | §1.1 + §1.2 + §1.3 + §1.7 (trailer fetch, classification, identity table, tests) + P6 | ✅ Done |
+| 3 | P3 + P4 + P5 (in-memory contributors, HEAD cache, bot-aware sampling) | ✅ Done |
+| 4 | §1.4 + §1.5 (config patterns, AI-attribution metrics & UI) | ✅ Done |
+| 5 | §1.6 (checkpoint session integration) + Part 3 items 3, 5, 6 | Pending |
 
-Phases 1 and 2 are independent and can land in either order; nothing here breaks the existing `isBot` contract, saved analyses, or the fallback tiers.
+Also landed along the way: the `findExpertForFile` fix (its commit filter matched against a file-list-less log, so the Copilot file-expert path always saw zero commits), `.mailmap` support via `%aN`/`%aE` (Part 3 item 2), the `Math.random()` changeFrequency removal (item 1), and the in-place `sampleCommits` sort fix (item 4). Nothing changed the existing `isBot` contract, saved analyses, or the fallback tiers.

--- a/PLAN-AGENT-DETECTION-AND-PERFORMANCE.md
+++ b/PLAN-AGENT-DETECTION-AND-PERFORMANCE.md
@@ -1,0 +1,242 @@
+# Team X-Ray: Agent Detection & Performance Improvement Plan
+
+## Why this plan exists
+
+[Entire](https://entire.io) — the platform launched by former GitHub CEO Thomas Dohmke — is built on one core observation: **AI agents now write a large share of code, and git only records the final diff, not who (or what) actually produced it.** Their first product, Checkpoints, captures agent sessions (prompts, reasoning, tool calls) and links them to commits through git itself:
+
+- A commit trailer `Entire-Checkpoint: <12-char hex id>` ties each commit to a captured agent session.
+- An `Entire-Attribution` trailer records how much of a commit came from the agent vs. the human.
+- Session metadata is stored on a dedicated `entire/checkpoints/v1` ref, so the record travels with the repo.
+- It plugs into every major coding agent: Claude Code, Codex, Cursor, Gemini CLI, Factory, Copilot.
+
+The lesson for Team X-Ray: **agent attribution lives in commit *messages and trailers*, not just in author name/email.** Most agent-assisted work is committed under the *human's* identity with a `Co-Authored-By:` trailer (Claude Code adds one by default; Cursor and Aider do too). Our current detector never sees any of that, because we only fetch `%s` (the subject line) and only inspect author name/email.
+
+This plan covers three things:
+
+1. **Part 1** — making bot/agent detection dramatically more accurate (the Entire-inspired work).
+2. **Part 2** — making the extension measurably faster (the analysis pipeline currently does every git scan twice).
+3. **Part 3** — other improvements noticed along the way.
+
+---
+
+## Where we stand today
+
+### Detection (`src/utils/bot-detection.ts`)
+
+`detectBotContributor(name, email)` is a 40-line heuristic over author name/email:
+
+- ✅ Catches GitHub App bots: `*[bot]` names, `<id>+<name>[bot]@users.noreply.github.com` emails, `dependabot`, `renovate`, `github-actions`.
+- ✅ Catches `noreply@anthropic.com` and `claude@users.noreply.github.com` authors.
+- ❌ Misses agents that commit as regular-looking authors: Cursor (`Cursor Agent <cursoragent@cursor.com>` / `agent@cursor.com`), OpenCode (`noreply@opencode.ai`), OpenHands (`openhands@all-hands.dev`), Aider.
+- ❌ Misses **all co-authored agent work** — a human-authored commit with `Co-Authored-By: Claude <noreply@anthropic.com>` counts as 100% human today.
+- ❌ Misses Entire's own `Entire-Checkpoint` / `Entire-Attribution` trailers — the strongest possible signal that a commit was agent-produced.
+- ❌ Binary output — no distinction between an *automation bot* (Dependabot bumping deps) and an *AI coding agent* (Claude Code shipping features), which mean very different things in a management-insights report.
+- ❌ Hard-coded lists — no user-extensible patterns for org-internal bots.
+
+### Pipeline (relevant to Part 2)
+
+`analyzeRepository()` (`src/core/expertise-analyzer.ts:97`) runs:
+
+1. `assessRepositorySize()` (line 160) → `getWorkspaceFiles()` + `getLocalGitCommits()` + `getLocalGitContributors()`, **sequentially**.
+2. `gatherRepositoryData()` (line 257) → **the exact same three calls again**, sequentially.
+
+`getLocalGitContributors()` runs `git shortlog -sne --all` (all refs, all history — ignoring the configured 90-day window) and then, in `git-worker.ts:87-101`, issues **two more sequential `git log --author` invocations per top-5 contributor** for first/last commit dates. `analyzeFileExperts()` (line 914) repeats the whole assess+gather double-scan on every right-click "Find Expert for This File". Nothing is cached between steps or commands.
+
+Net effect: a single "Analyze Repository" run spawns **~16 git processes where ~2 would do**, all before the AI is even contacted.
+
+---
+
+## Part 1 — Agent & bot detection, Entire-style
+
+### 1.1 Fetch trailers, not just subjects (foundation)
+
+Change the git log pretty-format in `git-worker.ts` / `git-service.ts` to include trailers and use control-character delimiters (fixes a latent parsing bug too — an author name containing `|` currently shifts every field):
+
+```
+--pretty=format:%H%x00%an%x00%ae%x00%aI%x00%s%x00%(trailers:key=Co-authored-by,valueonly,separator=;)%x00%(trailers:key=Entire-Checkpoint,valueonly)%x00%(trailers:key=Entire-Attribution,valueonly)%x1E
+```
+
+- `%x00` field separator, `%x1E` record separator — immune to `|` in names/subjects.
+- `%(trailers:key=...)` is computed by git itself; no need to fetch full bodies (`%B`) or parse them in JS, so the data volume stays almost identical.
+- Extend `GitCommit` (`src/types/expert.ts`) with `coAuthors: GitAuthor[]`, `checkpointId?: string`, `attribution?: string`.
+
+### 1.2 Replace the boolean with a classification
+
+New module shape for `bot-detection.ts`:
+
+```ts
+export type ContributorKind = 'human' | 'ai-agent' | 'automation-bot' | 'ai-assisted-human';
+
+export interface ContributorClassification {
+    kind: ContributorKind;
+    confidence: 'high' | 'medium' | 'low';
+    signals: string[];          // e.g. ['email:cursoragent@cursor.com', 'trailer:Entire-Checkpoint']
+    agentName?: string;         // 'Claude Code', 'Cursor', 'Dependabot', …
+    aiAssistRate?: number;      // share of the contributor's commits carrying agent signals
+}
+
+export function classifyContributor(
+    name: string | undefined,
+    email: string | undefined,
+    commits?: GitCommit[]       // optional: enables trailer-based signals
+): ContributorClassification;
+
+// Kept as a thin wrapper so all existing call sites and tests keep working:
+export function detectBotContributor(name?: string, email?: string): boolean;
+```
+
+- `isBot` on `Expert` stays (backwards compatible: `isBot = kind !== 'human' && kind !== 'ai-assisted-human'`), and we add `classification` alongside it.
+- `automation-bot` (Dependabot, Renovate, GitHub Actions) vs `ai-agent` (Claude Code, Cursor, Devin, Codex, …) render differently: dependency bots are noise to exclude; coding agents are a workforce to *measure*.
+
+### 1.3 Expand the identity table (data-driven, not if-chains)
+
+Move patterns into a declarative table so adding an agent is a one-line change. Confirmed identities to ship (sources at the end):
+
+| Agent | Author-side signal | Trailer/message signal |
+|---|---|---|
+| Claude Code | `noreply@anthropic.com` (already) | `Co-Authored-By: Claude* <noreply@anthropic.com>` |
+| GitHub Copilot agent | `copilot-swe-agent[bot]` | `Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>` |
+| Cursor | `cursoragent@cursor.com`, `agent@cursor.com`, name `Cursor Agent` | `Co-authored-by: Cursor Agent …` |
+| Devin | `devin-ai-integration[bot]` | — |
+| OpenAI Codex | `chatgpt-codex-connector[bot]` | — |
+| Google Jules | `google-labs-jules[bot]` | — |
+| Amazon Q | `amazon-q-developer[bot]` | — |
+| OpenCode | `noreply@opencode.ai` | — |
+| OpenHands | `openhands@all-hands.dev` | — |
+| Aider | `aider.chat` email domain | subject suffix `(aider)`, `Co-authored-by: aider (<model>) <…>` |
+| Entire-instrumented agents | — | `Entire-Checkpoint:` / `Entire-Attribution:` trailers (any agent run under Entire CLI) |
+
+Generic rules stay (any `[bot]` name, GitHub App noreply pattern), so future GitHub-App agents are caught automatically.
+
+### 1.4 User-configurable patterns
+
+New settings in `package.json`:
+
+- `teamxray.additionalBotPatterns: string[]` — glob/regex over `name <email>` for org-internal bots and agents.
+- `teamxray.humanOverrides: string[]` — emails to *never* classify as bots (escape hatch for false positives).
+
+### 1.5 "AI-assisted" as a first-class metric (the Entire-inspired feature)
+
+With trailers available per commit, compute during `extractContributorsFromCommits` / contributor aggregation:
+
+- **Per contributor:** `aiAssistRate` = share of their commits carrying an agent co-author, an `Entire-Checkpoint` trailer, or an aider marker. A human with 80% Claude-co-authored commits is classified `ai-assisted-human` — shown as human, badged differently (e.g. `🤝`), never dropped from insights.
+- **Per repository:** agent-written share of commits, trend over the analysis window, breakdown by agent (`Claude Code 34%, Cursor 12%, Dependabot 9%`).
+- **Surfacing:** a new "AI Attribution" card in the webview + HTML report next to the existing `N humans · M agents` pill; feed the numbers into `analysis-enrichment.ts` so management insights can say things like "60% of commits in `src/core` are agent-assisted with a single human reviewer — review-capacity risk", and so bus-factor math stops counting bots as owners.
+- **Prompt enrichment:** include the attribution summary in the AI prompt (`buildAnalysisPrompt`) — it materially improves the quality of team-dynamics output because the model stops inventing personalities for Dependabot.
+
+### 1.6 Optional: native Entire Checkpoints integration (stretch)
+
+If the repo has Entire installed (`git show-ref --verify refs/heads/entire/checkpoints/v1` or the ref on origin), Team X-Ray can:
+
+- Show a "session context available" link per commit/expert that deep-links to `entire.io` via the checkpoint ID.
+- Parse `Entire-Attribution` values for line-level agent/human split instead of estimating from co-authorship.
+
+Cheap to detect (one `git show-ref`), high wow-factor, degrades gracefully when absent.
+
+### 1.7 Tests
+
+- Unit-test the classification table: one fixture per agent identity above, plus co-author-trailer fixtures and `humanOverrides` behavior (extend `src/core/__tests__/copilot-service.test.ts` patterns into a dedicated `bot-detection.test.ts`).
+- Fixture a NUL-delimited log output with `|` in an author name to lock in the parser fix.
+
+---
+
+## Part 2 — Performance plan
+
+Ordered by impact-per-effort. Items P1–P3 together should cut the pre-AI "gathering" phase from ~16 git spawns to 2–3 and roughly 3–4× the wall-clock speed of that phase; P4 makes repeat commands near-instant.
+
+### P1. Gather once, not twice (biggest win, low risk)
+
+`assessRepositorySize()` and `gatherRepositoryData()` each independently fetch files + commits + contributors (`expertise-analyzer.ts:160-164` and `265-267`). Restructure:
+
+```ts
+const snapshot = await this.collectRepoSnapshot();   // one fetch of files/commits/contributors
+const repoStats = this.assessRepositorySize(snapshot);   // pure function, no I/O
+const repositoryData = this.buildRepositoryData(snapshot, repoStats); // pure sampling
+```
+
+Halves git process count and `findFiles` traversals immediately. `analyzeFileExperts()` (line 914) uses the same snapshot instead of re-running both steps per right-click.
+
+### P2. Parallelize the remaining fetches
+
+The three snapshot fetches are independent; the worker client already multiplexes by message id:
+
+```ts
+const [files, commits, contributors] = await Promise.all([
+    this.getWorkspaceFiles(),
+    this.getLocalGitCommits(),
+    this.getLocalGitContributors(),
+]);
+```
+
+Latency drops from sum to max of the three.
+
+### P3. Derive contributors from the commit list — drop `shortlog --all` and the per-author date loops
+
+`git shortlog -sne --all` walks **all refs and all history**, which (a) is the slowest git call we make on large repos and (b) contradicts the `historyWindowDays` setting (commits respect the 90-day window; contributor counts don't — bots retired years ago still appear). Meanwhile `git-worker.ts:87-101` spawns up to 10 more sequential `git log --author` processes for first/last dates — and `--reverse -n 1` re-walks full history per author.
+
+Replace all of it with one in-memory pass over the already-fetched commit array (the logic exists — `extractContributorsFromCommits`, `expertise-analyzer.ts:892` — today it's only a fallback): counts, first/last dates, co-author stats, and AI-assist rates all fall out of a single loop. Keep `shortlog` only for the `historyWindowDays: 0` + >1000-commits edge case, without `--all` (use `HEAD`).
+
+### P4. Cache the snapshot with HEAD-based invalidation
+
+Store the snapshot keyed by `git rev-parse HEAD` (one ~5ms invocation). "Analyze Repository" followed by "Find Expert for This File" — or two file-expert lookups in a row — currently re-runs everything; with the cache they cost one `rev-parse`. Invalidate on HEAD change or `historyWindowDays` change; keep the existing worker-thread architecture (it's good — keeps the extension host responsive).
+
+### P5. Bot-aware sampling → smaller prompts, faster + better AI calls
+
+`sampleContributors()` takes the top-N by commit count — and Dependabot/Renovate are often top committers, so **bots crowd humans out of the AI's view** and burn prompt tokens on churn commits. After classification (Part 1):
+
+- Sample humans and agents separately; send bots as a one-line aggregate ("Dependabot: 214 dependency commits") instead of full profiles.
+- Optionally filter agent bump-commits out of the sampled commit list sent to the model.
+
+Smaller prompts = faster + cheaper AI round-trip and fewer chunked-analysis paths (`performChunkedAnalysis` triggers at >100KB).
+
+### P6. Robust parsing (correctness with a perf face)
+
+The NUL/record-separator format from §1.1 also removes the `split('|')` fragility and the multi-block `__TEAMXRAY_COMMIT__` custom parsing in `parseCommitOutputWithFiles`.
+
+### P7. Instrument before/after
+
+Add duration logging around each phase (`snapshot`, `sampling`, `ai`, `render`) to the output channel, e.g. `⏱ snapshot 420ms · sampling 3ms · ai 28s`. Cheap, and turns future perf regressions into bug reports with numbers.
+
+### Expected impact summary
+
+| Scenario | Today | After P1–P4 |
+|---|---|---|
+| Analyze Repository (pre-AI phase) | ~16 git spawns, 2× workspace scans, serial | 2–3 spawns, 1 scan, parallel |
+| Find Expert for This File | ~8 git spawns + workspace scan per invocation | 1 `rev-parse` (cache hit) |
+| Contributor dates on large repo | up to 10 full-history walks | 0 (derived in memory) |
+| Prompt size w/ bot-heavy repos | bots occupy top contributor slots | humans + agents only, bots aggregated |
+
+---
+
+## Part 3 — Other suggestions noticed along the way
+
+1. **`changeFrequency` is fake data.** `mapFileExpertise` fills it with `Math.floor(Math.random() * 10) + 1` (`expertise-analyzer.ts:1304`) and reports render it. Either compute it from the per-file commit counts we already fetch, or drop the field.
+2. **Identity merging (.mailmap).** The same human with work + personal emails is counted as two contributors, which skews bus-factor and top-contributor math. Respect `.mailmap` (`git log` does automatically with `%aN`/`%aE` — a one-character format change) and optionally merge by normalized display name.
+3. **Report/webview duplication.** `expertise-webview.ts` (1576 lines) and `report-generator.ts` (452) maintain near-identical HTML/CSS by hand — the humans/agents pill markup exists in 4 places. Extracting a shared template module would make Part 1's new badges (`🤝 AI-assisted`, per-agent breakdown) a single-site change.
+4. **`sampleCommits` mutates its input** (`.sort()` in place, line 347) — sort a copy to avoid surprising callers that reuse `allCommits`.
+5. **Bounded webview payloads.** For enterprise-size analyses, the webview receives the full expert/file arrays; consider top-N + "show more" to keep the panel snappy.
+6. **CI check for the identity table.** A tiny scheduled job (or eval in `evals/`) that runs classification against a fixture corpus keeps the agent table honest as new agents appear — the ecosystem added at least four new commit identities in the last year.
+
+---
+
+## Suggested rollout
+
+| Phase | Scope | Size |
+|---|---|---|
+| 1 | P1 + P2 + P7 (single snapshot, parallel, timings) — pure refactor, no behavior change | S |
+| 2 | §1.1 + §1.2 + §1.3 + §1.7 (trailer fetch, classification, identity table, tests) + P6 | M |
+| 3 | P3 + P4 + P5 (in-memory contributors, HEAD cache, bot-aware sampling) | M |
+| 4 | §1.4 + §1.5 (config patterns, AI-attribution metrics & UI) | M |
+| 5 | §1.6 (Entire Checkpoints deep-links) + Part 3 items | S–M |
+
+Phases 1 and 2 are independent and can land in either order; nothing here breaks the existing `isBot` contract, saved analyses, or the fallback tiers.
+
+---
+
+## Sources
+
+- [Entire blog](https://entire.io/blog) · [Hello Entire World](https://entire.io/blog/hello-entire-world) · [The Entire CLI: How It Works](https://entire.io/blog/the-entire-cli-how-it-works-and-where-its-headed) · [Agent Hooks](https://entire.io/blog/agent-hooks-the-integration-layer-between-entire-cli-and-your-agent)
+- [Entire docs — Core Concepts](https://docs.entire.io/core-concepts) · [entireio/cli on GitHub](https://github.com/entireio/cli)
+- [TechCrunch: Former GitHub CEO raises record $60M seed](https://techcrunch.com/2026/02/10/former-github-ceo-raises-record-60m-dev-tool-seed-round-at-300m-valuation/) · [The New Stack interview with Thomas Dohmke](https://thenewstack.io/thomas-dohmke-interview-entire/)
+- [Detecting AI Coding Agents in Open Source: A Validated Multi-Method Census (arXiv)](https://arxiv.org/html/2606.24429v1) · [Fingerprinting AI Coding Agents on GitHub (arXiv)](https://arxiv.org/html/2601.17406v1)
+- [powerset-co/github-coding-agent-tracker](https://github.com/powerset-co/github-coding-agent-tracker) (agent commit-identity list) · [Coderbuds open-source AI-detection rules](https://coderbuds.com/blog/open-source-ai-code-detection-yaml-rules)

--- a/PLAN-AGENT-DETECTION-AND-PERFORMANCE.md
+++ b/PLAN-AGENT-DETECTION-AND-PERFORMANCE.md
@@ -2,18 +2,13 @@
 
 ## Why this plan exists
 
-[Entire](https://entire.io) — the platform launched by former GitHub CEO Thomas Dohmke — is built on one core observation: **AI agents now write a large share of code, and git only records the final diff, not who (or what) actually produced it.** Their first product, Checkpoints, captures agent sessions (prompts, reasoning, tool calls) and links them to commits through git itself:
+AI agents now write a large share of code, and git only records the final diff — not who (or what) actually produced it. The tooling ecosystem is converging on commit *trailers* as the attribution mechanism: agents record their involvement in the commit message body (`Co-Authored-By:` lines, checkpoint/attribution trailers), while the commit's author fields stay the human's.
 
-- A commit trailer `Entire-Checkpoint: <12-char hex id>` ties each commit to a captured agent session.
-- An `Entire-Attribution` trailer records how much of a commit came from the agent vs. the human.
-- Session metadata is stored on a dedicated `entire/checkpoints/v1` ref, so the record travels with the repo.
-- It plugs into every major coding agent: Claude Code, Codex, Cursor, Gemini CLI, Factory, Copilot.
-
-The lesson for Team X-Ray: **agent attribution lives in commit *messages and trailers*, not just in author name/email.** Most agent-assisted work is committed under the *human's* identity with a `Co-Authored-By:` trailer (Claude Code adds one by default; Cursor and Aider do too). Our current detector never sees any of that, because we only fetch `%s` (the subject line) and only inspect author name/email.
+That means **agent attribution lives in commit messages and trailers, not just in author name/email.** Most agent-assisted work is committed under the *human's* identity with a `Co-Authored-By:` trailer (Claude Code adds one by default; Cursor and Aider do too). Team X-Ray's current detector never sees any of that, because we only fetch `%s` (the subject line) and only inspect author name/email.
 
 This plan covers three things:
 
-1. **Part 1** — making bot/agent detection dramatically more accurate (the Entire-inspired work).
+1. **Part 1** — making bot/agent detection dramatically more accurate (trailer-aware classification).
 2. **Part 2** — making the extension measurably faster (the analysis pipeline currently does every git scan twice).
 3. **Part 3** — other improvements noticed along the way.
 
@@ -29,7 +24,7 @@ This plan covers three things:
 - ✅ Catches `noreply@anthropic.com` and `claude@users.noreply.github.com` authors.
 - ❌ Misses agents that commit as regular-looking authors: Cursor (`Cursor Agent <cursoragent@cursor.com>` / `agent@cursor.com`), OpenCode (`noreply@opencode.ai`), OpenHands (`openhands@all-hands.dev`), Aider.
 - ❌ Misses **all co-authored agent work** — a human-authored commit with `Co-Authored-By: Claude <noreply@anthropic.com>` counts as 100% human today.
-- ❌ Misses Entire's own `Entire-Checkpoint` / `Entire-Attribution` trailers — the strongest possible signal that a commit was agent-produced.
+- ❌ Misses checkpoint/attribution trailers (`Entire-Checkpoint` / `Entire-Attribution`) that session-capture tooling writes into commits — the strongest possible signal that a commit was agent-produced.
 - ❌ Binary output — no distinction between an *automation bot* (Dependabot bumping deps) and an *AI coding agent* (Claude Code shipping features), which mean very different things in a management-insights report.
 - ❌ Hard-coded lists — no user-extensible patterns for org-internal bots.
 
@@ -46,7 +41,7 @@ Net effect: a single "Analyze Repository" run spawns **~16 git processes where ~
 
 ---
 
-## Part 1 — Agent & bot detection, Entire-style
+## Part 1 — Agent & bot detection, trailer-aware
 
 ### 1.1 Fetch trailers, not just subjects (foundation)
 
@@ -90,7 +85,7 @@ export function detectBotContributor(name?: string, email?: string): boolean;
 
 ### 1.3 Expand the identity table (data-driven, not if-chains)
 
-Move patterns into a declarative table so adding an agent is a one-line change. Confirmed identities to ship (sources at the end):
+Move patterns into a declarative table so adding an agent is a one-line change. Confirmed identities to ship:
 
 | Agent | Author-side signal | Trailer/message signal |
 |---|---|---|
@@ -104,7 +99,7 @@ Move patterns into a declarative table so adding an agent is a one-line change. 
 | OpenCode | `noreply@opencode.ai` | — |
 | OpenHands | `openhands@all-hands.dev` | — |
 | Aider | `aider.chat` email domain | subject suffix `(aider)`, `Co-authored-by: aider (<model>) <…>` |
-| Entire-instrumented agents | — | `Entire-Checkpoint:` / `Entire-Attribution:` trailers (any agent run under Entire CLI) |
+| Session-capture tooling | — | `Entire-Checkpoint:` / `Entire-Attribution:` trailers (any agent run under checkpoint instrumentation) |
 
 Generic rules stay (any `[bot]` name, GitHub App noreply pattern), so future GitHub-App agents are caught automatically.
 
@@ -115,7 +110,7 @@ New settings in `package.json`:
 - `teamxray.additionalBotPatterns: string[]` — glob/regex over `name <email>` for org-internal bots and agents.
 - `teamxray.humanOverrides: string[]` — emails to *never* classify as bots (escape hatch for false positives).
 
-### 1.5 "AI-assisted" as a first-class metric (the Entire-inspired feature)
+### 1.5 "AI-assisted" as a first-class metric
 
 With trailers available per commit, compute during `extractContributorsFromCommits` / contributor aggregation:
 
@@ -124,11 +119,11 @@ With trailers available per commit, compute during `extractContributorsFromCommi
 - **Surfacing:** a new "AI Attribution" card in the webview + HTML report next to the existing `N humans · M agents` pill; feed the numbers into `analysis-enrichment.ts` so management insights can say things like "60% of commits in `src/core` are agent-assisted with a single human reviewer — review-capacity risk", and so bus-factor math stops counting bots as owners.
 - **Prompt enrichment:** include the attribution summary in the AI prompt (`buildAnalysisPrompt`) — it materially improves the quality of team-dynamics output because the model stops inventing personalities for Dependabot.
 
-### 1.6 Optional: native Entire Checkpoints integration (stretch)
+### 1.6 Optional: checkpoint session integration (stretch)
 
-If the repo has Entire installed (`git show-ref --verify refs/heads/entire/checkpoints/v1` or the ref on origin), Team X-Ray can:
+If the repo carries checkpoint instrumentation (`git show-ref --verify refs/heads/entire/checkpoints/v1` or the ref on origin), Team X-Ray can:
 
-- Show a "session context available" link per commit/expert that deep-links to `entire.io` via the checkpoint ID.
+- Surface a "session context available" indicator per commit/expert, keyed by the checkpoint ID.
 - Parse `Entire-Attribution` values for line-level agent/human split instead of estimating from co-authorship.
 
 Cheap to detect (one `git show-ref`), high wow-factor, degrades gracefully when absent.
@@ -227,16 +222,6 @@ Add duration logging around each phase (`snapshot`, `sampling`, `ai`, `render`) 
 | 2 | §1.1 + §1.2 + §1.3 + §1.7 (trailer fetch, classification, identity table, tests) + P6 | M |
 | 3 | P3 + P4 + P5 (in-memory contributors, HEAD cache, bot-aware sampling) | M |
 | 4 | §1.4 + §1.5 (config patterns, AI-attribution metrics & UI) | M |
-| 5 | §1.6 (Entire Checkpoints deep-links) + Part 3 items | S–M |
+| 5 | §1.6 (checkpoint session integration) + Part 3 items | S–M |
 
 Phases 1 and 2 are independent and can land in either order; nothing here breaks the existing `isBot` contract, saved analyses, or the fallback tiers.
-
----
-
-## Sources
-
-- [Entire blog](https://entire.io/blog) · [Hello Entire World](https://entire.io/blog/hello-entire-world) · [The Entire CLI: How It Works](https://entire.io/blog/the-entire-cli-how-it-works-and-where-its-headed) · [Agent Hooks](https://entire.io/blog/agent-hooks-the-integration-layer-between-entire-cli-and-your-agent)
-- [Entire docs — Core Concepts](https://docs.entire.io/core-concepts) · [entireio/cli on GitHub](https://github.com/entireio/cli)
-- [TechCrunch: Former GitHub CEO raises record $60M seed](https://techcrunch.com/2026/02/10/former-github-ceo-raises-record-60m-dev-tool-seed-round-at-300m-valuation/) · [The New Stack interview with Thomas Dohmke](https://thenewstack.io/thomas-dohmke-interview-entire/)
-- [Detecting AI Coding Agents in Open Source: A Validated Multi-Method Census (arXiv)](https://arxiv.org/html/2606.24429v1) · [Fingerprinting AI Coding Agents on GitHub (arXiv)](https://arxiv.org/html/2601.17406v1)
-- [powerset-co/github-coding-agent-tracker](https://github.com/powerset-co/github-coding-agent-tracker) (agent commit-identity list) · [Coderbuds open-source AI-detection rules](https://coderbuds.com/blog/open-source-ai-code-detection-yaml-rules)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,14 +55,23 @@ Copilot SDK session (default or BYOK override) → GitHub Models API → Reduced
 
 BYOK is a Copilot session configuration, not a separate fallback tier. If the configured Copilot/BYOK session fails, Team X-Ray falls through to GitHub Models, then to the reduced local fallback.
 
-## Bot Detection
+## Agent & Bot Detection
 
-The `detectBot()` helper identifies automated contributors (Dependabot, Renovate, GitHub Actions bots, Copilot) by matching name and email patterns against known bot signatures.
+`classifyContributor()` (in `utils/bot-detection.ts`) classifies every contributor into one of four kinds using two signal layers:
 
-Detected bots get:
-- Gray expertise bars (instead of colored)
-- A 🤖 badge next to their name
-- Separation from human contributors in management insights
+1. **Author identity** — name/email matched against a declarative table of known AI coding agents (Claude Code, Copilot, Cursor, Devin, Codex, Jules, Amazon Q, OpenCode, OpenHands, Aider) and automation bots (Dependabot, Renovate, GitHub Actions), plus generic `[bot]` patterns.
+2. **Commit trailers** — `Co-authored-by` lines, checkpoint/attribution trailers (`Entire-Checkpoint` / `Entire-Attribution`), and the aider subject marker. Git extracts these in the same `git log` call via `%(trailers:key=...)`, so most agent-assisted work committed under a *human's* identity is still detected.
+
+| Kind | Meaning | Rendering |
+|------|---------|-----------|
+| `human` | No bot/agent signals | Normal |
+| `ai-agent` | AI coding agent committing under its own identity | 🤖 badge, gray bars, excluded from human insights |
+| `automation-bot` | Dependency/CI automation | 🤖 badge; aggregated to a one-line summary instead of occupying contributor slots in the AI prompt |
+| `ai-assisted-human` | Human whose commits frequently carry agent co-author trailers | 🤝 badge; stays in all human-focused insights, with an AI-assist rate |
+
+The analysis also rolls commit-level signals up into a repository **AI attribution summary** (share of AI-assisted commits, breakdown by agent) shown as a pill in the webview/report header and fed into the AI prompt.
+
+Detection is user-extensible via two settings: `teamxray.additionalBotPatterns` (extra identities to treat as bots) and `teamxray.humanOverrides` (emails never classified as bots). The legacy boolean `detectBotContributor()` remains as a thin wrapper for backwards compatibility.
 
 ## Worker Thread
 

--- a/package.json
+++ b/package.json
@@ -207,6 +207,22 @@
           "default": 90,
           "minimum": 0,
           "description": "Limit git history to the last N days. Set to 0 to analyze all history (still capped at 1000 commits)."
+        },
+        "teamxray.additionalBotPatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Extra case-insensitive substrings matched against contributor \"name <email>\" identities. Matches are classified as automation bots (e.g. org-internal CI accounts)."
+        },
+        "teamxray.humanOverrides": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Contributor emails that must never be classified as bots or agents, overriding all detection patterns."
         }
       }
     }

--- a/src/core/expertise-analyzer.ts
+++ b/src/core/expertise-analyzer.ts
@@ -11,12 +11,18 @@ import {
     RepositoryData,
     RepositoryStats,
     ManagementInsight,
-    TeamHealthMetrics
+    TeamHealthMetrics,
+    AiAttributionSummary,
+    GitCommit
 } from '../types/expert';
 import { ErrorHandler } from '../utils/error-handler';
 import { ResourceManager } from '../utils/resource-manager';
 import { Validator } from '../utils/validation';
-import { detectBotContributor } from '../utils/bot-detection';
+import {
+    detectBotContributor,
+    classifyContributor,
+    detectCommitAgentSignals
+} from '../utils/bot-detection';
 import {
     buildFallbackManagementInsights,
     buildFallbackTeamHealthMetrics,
@@ -30,6 +36,14 @@ export interface ExpertiseAnalysis extends AnalysisResult {
     challengeMatching?: ChallengeMatching;
     managementInsights?: ManagementInsight[];
     teamHealthMetrics?: TeamHealthMetrics;
+    aiAttribution?: AiAttributionSummary;
+}
+
+/** One in-memory pass over the repo: files, commits, and contributors derived from those commits. */
+interface RepoSnapshot {
+    files: string[];
+    commits: GitCommit[];
+    contributors: any[];
 }
 
 export interface TeamDynamics {
@@ -67,6 +81,7 @@ export class ExpertiseAnalyzer {
     private resourceManager: ResourceManager;
     private gitService: GitService | null = null;
     private gitWorkerClient: GitWorkerClient | null = null;
+    private snapshotCache: { head: string; windowDays: number; snapshot: RepoSnapshot } | null = null;
 
     // Limits for different repository sizes
     private readonly SIZE_LIMITS = {
@@ -122,12 +137,19 @@ export class ExpertiseAnalyzer {
                 }
             }
 
-            // Step 3: Assess repository size and characteristics
-            const repoStats = await this.assessRepositorySize();
+            // Step 3: Collect repository data once (files + commits in parallel,
+            // contributors derived in memory) and assess size from it
+            const snapshotStart = Date.now();
+            const snapshot = await this.collectRepoSnapshot();
+            const snapshotMs = Date.now() - snapshotStart;
+
+            const repoStats = this.assessRepositorySize(snapshot);
             this.outputChannel.appendLine(`📏 Repository size: ${repoStats.repositorySize} (${repoStats.totalFiles} files, ${repoStats.totalContributors} contributors)`);
 
-            // Step 4: Gather repository data with size-appropriate limits
-            const repositoryData = await this.gatherRepositoryData(repositoryName, repoStats);
+            // Step 4: Apply size-appropriate sampling
+            const samplingStart = Date.now();
+            const repositoryData = this.gatherRepositoryData(repositoryName, repoStats, snapshot);
+            const samplingMs = Date.now() - samplingStart;
             if (!repositoryData) {
                 throw ErrorHandler.createError(
                     'ANALYSIS_FAILED',
@@ -138,7 +160,9 @@ export class ExpertiseAnalyzer {
             }
 
             // Step 5: Perform AI analysis with chunking for large repos
+            const aiStart = Date.now();
             const analysis = await this.performSmartAIAnalysis(repositoryData, repoStats, onDelta);
+            const aiMs = Date.now() - aiStart;
             if (!analysis) {
                 throw ErrorHandler.createError(
                     'ANALYSIS_FAILED',
@@ -148,6 +172,13 @@ export class ExpertiseAnalyzer {
                 );
             }
 
+            // Attach git-derived AI attribution and expert classifications —
+            // computed locally, independent of what the AI returned
+            this.enrichAnalysisWithAttribution(analysis, repositoryData);
+
+            this.outputChannel.appendLine(
+                `⏱ Timings: snapshot ${snapshotMs}ms · sampling ${samplingMs}ms · ai ${Math.round(aiMs / 1000)}s`
+            );
             this.outputChannel.appendLine('✅ Analysis completed successfully!');
             return analysis;
 
@@ -155,13 +186,61 @@ export class ExpertiseAnalyzer {
     }
 
     /**
-     * Assesses repository size and characteristics to determine analysis strategy
+     * Collect files, commits, and contributors in one pass. Files and commits
+     * are fetched in parallel; contributors (with first/last dates and AI-assist
+     * stats) are derived from the commit list in memory instead of separate
+     * `git shortlog` + per-author date invocations. Results are cached keyed
+     * on HEAD and the configured history window, so repeated commands within
+     * a session cost a single `git rev-parse`.
      */
-    private async assessRepositorySize(): Promise<RepositoryStats> {
+    private async collectRepoSnapshot(): Promise<RepoSnapshot> {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            return { files: [], commits: [], contributors: [] };
+        }
+
+        const repoPath = workspaceFolder.uri.fsPath;
+        const windowDays = vscode.workspace.getConfiguration('teamxray').get<number>('historyWindowDays', 90);
+
+        let head = '';
         try {
-            const files = await this.getWorkspaceFiles();
-            const commits = await this.getLocalGitCommits();
-            const contributors = await this.getLocalGitContributors();
+            head = await this.getOrCreateWorkerClient().getHead(repoPath);
+        } catch {
+            // Not a git repo or git unavailable — proceed uncached
+        }
+
+        if (head && this.snapshotCache &&
+            this.snapshotCache.head === head &&
+            this.snapshotCache.windowDays === windowDays) {
+            this.outputChannel.appendLine('⚡ Using cached repository snapshot (HEAD unchanged)');
+            return this.snapshotCache.snapshot;
+        }
+
+        const [files, commits] = await Promise.all([
+            this.getWorkspaceFiles(),
+            this.getLocalGitCommits()
+        ]);
+
+        let contributors = this.extractContributorsFromCommits(commits);
+        if (contributors.length === 0) {
+            // Degenerate case (no parseable commits) — fall back to shortlog
+            contributors = await this.getLocalGitContributors();
+        }
+
+        const snapshot: RepoSnapshot = { files, commits, contributors };
+        if (head) {
+            this.snapshotCache = { head, windowDays, snapshot };
+        }
+        return snapshot;
+    }
+
+    /**
+     * Assesses repository size and characteristics to determine analysis strategy.
+     * Pure computation over an already-collected snapshot — no git/FS access.
+     */
+    private assessRepositorySize(snapshot: RepoSnapshot): RepositoryStats {
+        try {
+            const { files, commits, contributors } = snapshot;
 
             // Determine repository size
             let repositorySize: 'small' | 'medium' | 'large' | 'enterprise' = 'small';
@@ -254,27 +333,41 @@ export class ExpertiseAnalyzer {
     /**
      * Gathers repository data with size-appropriate limits
      */
-    private async gatherRepositoryData(repositoryName: string, repoStats: RepositoryStats): Promise<any> {
+    private gatherRepositoryData(repositoryName: string, repoStats: RepositoryStats, snapshot: RepoSnapshot): any {
         try {
             this.outputChannel.appendLine('📥 Gathering repository data with smart limits...');
 
             const limits = this.SIZE_LIMITS[repoStats.repositorySize];
             this.outputChannel.appendLine(`🎯 Using ${repoStats.repositorySize} repo limits: ${limits.files} files, ${limits.contributors} contributors, ${limits.commits} commits`);
 
-            // Get limited data sets
-            const allFiles = await this.getWorkspaceFiles();
-            const allCommits = await this.getLocalGitCommits();
-            const allContributors = await this.getLocalGitContributors();
+            const { files: allFiles, commits: allCommits, contributors: allContributors } = snapshot;
+
+            // Bot-aware split: automation bots (Dependabot, Renovate, …) are
+            // aggregated into a one-line summary instead of occupying top
+            // contributor slots and prompt tokens; humans and AI agents are
+            // sampled normally.
+            const automationBots = allContributors.filter(c => c.contributorKind === 'automation-bot');
+            const analyzableContributors = allContributors.filter(c => c.contributorKind !== 'automation-bot');
+            const botEmails = new Set(automationBots.map(c => c.email));
+
+            const analyzableCommits = allCommits.filter(c => !botEmails.has(c.author?.email));
 
             // Apply intelligent sampling
             const files = this.sampleFiles(allFiles, limits.files);
-            const commits = this.sampleCommits(allCommits, limits.commits);
-            const contributors = this.sampleContributors(allContributors, limits.contributors);
+            const commits = this.sampleCommits(analyzableCommits, limits.commits);
+            const contributors = this.sampleContributors(analyzableContributors, limits.contributors);
+
+            const botSummary = automationBots
+                .map(c => `${c.name}: ${c.commits} automated commits`)
+                .join('; ');
+
+            const aiAttribution = this.computeAiAttribution(allCommits, botEmails);
 
             this.outputChannel.appendLine(
                 `📊 Sampled data: ${files.length}/${allFiles.length} files, ` +
                 `${contributors.length}/${allContributors.length} contributors, ` +
-                `${commits.length}/${allCommits.length} commits`
+                `${commits.length}/${allCommits.length} commits` +
+                (automationBots.length > 0 ? ` (${automationBots.length} automation bots aggregated)` : '')
             );
 
             return {
@@ -284,6 +377,9 @@ export class ExpertiseAnalyzer {
                 contributors,
                 pullRequests: [],
                 repositoryStats: repoStats,
+                botSummary,
+                aiAttribution,
+                allContributors,
                 samplingApplied: {
                     originalFiles: allFiles.length,
                     originalCommits: allCommits.length,
@@ -294,6 +390,73 @@ export class ExpertiseAnalyzer {
         } catch (error) {
             this.outputChannel.appendLine(`❌ Error gathering repository data: ${error}`);
             throw error;
+        }
+    }
+
+    /**
+     * Roll up commit-level agent signals into a repository summary:
+     * how much of the history is agent-assisted, and by which agents.
+     */
+    private computeAiAttribution(commits: GitCommit[], automationBotEmails: Set<string>): AiAttributionSummary {
+        let assistedCommits = 0;
+        let automationBotCommits = 0;
+        const byAgent: Record<string, number> = {};
+
+        for (const commit of commits) {
+            if (automationBotEmails.has(commit.author?.email)) {
+                automationBotCommits++;
+                continue;
+            }
+            const authorClassification = classifyContributor(commit.author?.name, commit.author?.email);
+            if (authorClassification.kind === 'ai-agent') {
+                assistedCommits++;
+                const agent = authorClassification.agentName ?? 'Unknown agent';
+                byAgent[agent] = (byAgent[agent] ?? 0) + 1;
+                continue;
+            }
+            const signals = detectCommitAgentSignals(commit);
+            if (signals.assisted) {
+                assistedCommits++;
+                for (const agent of signals.agents) {
+                    byAgent[agent] = (byAgent[agent] ?? 0) + 1;
+                }
+            }
+        }
+
+        return {
+            totalCommits: commits.length,
+            assistedCommits,
+            assistedShare: commits.length > 0 ? assistedCommits / commits.length : 0,
+            byAgent,
+            automationBotCommits,
+        };
+    }
+
+    /**
+     * Attach locally computed attribution to the final analysis: the repo-level
+     * rollup plus per-expert classification (kind, AI-assist rate, agent name)
+     * matched by email against the git-derived contributor list.
+     */
+    private enrichAnalysisWithAttribution(analysis: ExpertiseAnalysis, repositoryData: any): void {
+        if (repositoryData.aiAttribution) {
+            analysis.aiAttribution = repositoryData.aiAttribution;
+        }
+
+        const byEmail = new Map<string, any>(
+            (repositoryData.allContributors ?? repositoryData.contributors ?? [])
+                .map((c: any) => [String(c.email ?? '').toLowerCase(), c])
+        );
+
+        for (const expert of [...(analysis.expertProfiles ?? []), ...(analysis.experts ?? [])]) {
+            const contributor = byEmail.get(String(expert.email ?? '').toLowerCase());
+            if (contributor) {
+                expert.contributorKind = contributor.contributorKind ?? expert.contributorKind;
+                expert.aiAssistRate = contributor.aiAssistRate ?? expert.aiAssistRate;
+                expert.agentName = contributor.agentName ?? expert.agentName;
+                if (contributor.contributorKind === 'ai-agent' || contributor.contributorKind === 'automation-bot') {
+                    expert.isBot = true;
+                }
+            }
         }
     }
 
@@ -343,8 +506,8 @@ export class ExpertiseAnalyzer {
     private sampleCommits(commits: any[], limit: number): any[] {
         if (commits.length <= limit) return commits;
 
-        // Sort by date (newest first) and take a mix of recent and distributed
-        const sorted = commits.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+        // Sort a copy by date (newest first) and take a mix of recent and distributed
+        const sorted = [...commits].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
         
         // Take 70% recent commits, 30% distributed throughout history
         const recentCount = Math.floor(limit * 0.7);
@@ -696,6 +859,16 @@ export class ExpertiseAnalyzer {
 
         const filesSample = repositoryData.files.slice(0, maxFiles).join(', ');
 
+        const attribution = repositoryData.aiAttribution;
+        const attributionInfo = attribution && attribution.assistedCommits > 0
+            ? `\nAI Attribution (from commit trailers): ${attribution.assistedCommits}/${attribution.totalCommits} commits (${Math.round(attribution.assistedShare * 100)}%) were AI-agent-assisted.` +
+              ` By agent: ${Object.entries(attribution.byAgent).map(([agent, count]) => `${agent} ${count}`).join(', ')}.` +
+              ' Treat AI agents as tooling, not team members — focus personality and growth insights on the humans, and consider review-capacity risk where AI-assisted share is high.\n'
+            : '';
+        const botInfo = repositoryData.botSummary
+            ? `\nAutomation bots (excluded from team profiles): ${repositoryData.botSummary}\n`
+            : '';
+
         return `You are an AI assistant helping engineering managers understand their team dynamics and make data-driven decisions. Analyze this ${repoStats.repositorySize} software repository for actionable management insights.
 
 Repository: ${repositoryData.repository}
@@ -708,7 +881,7 @@ ${contributorsInfo}
 
 Recent Communication Patterns (${maxCommits} commits):
 ${recentCommitMessages}
-
+${attributionInfo}${botInfo}
 Key Files: ${filesSample}
 
 ENGINEERING MANAGER FOCUS AREAS:
@@ -801,11 +974,10 @@ Respond with JSON only (NO markdown, NO explanations):
                         if (!this.gitService) {
                             this.gitService = new GitService(workspaceFolder.uri.fsPath, this.outputChannel);
                         }
-                        const commits = await this.gitService.getCommits(200);
-                        const fileCommits = commits.filter((c: any) =>
-                            c.files?.some((f: string) => f.includes(filePath) || filePath.includes(f))
-                        );
-                        const repoStats = await this.assessRepositorySize();
+                        // Per-file history (with --follow) — a plain `git log`
+                        // carries no file lists, so filtering it finds nothing
+                        const fileCommits = await this.gitService.getCommitsForFile(filePath, 200);
+                        const repoStats = this.assessRepositorySize(await this.collectRepoSnapshot());
                         const minimalData: RepositoryData = {
                             repository: workspaceFolder.name,
                             files: [],
@@ -889,29 +1061,61 @@ Respond with JSON only (NO markdown, NO explanations):
         }
     }
 
-        private extractContributorsFromCommits(commits: any[]): any[] {
-        const authorMap = new Map<string, { name: string; email: string; commits: number; lastCommit: string }>();
+    /**
+     * Derive contributors from a commit list in one in-memory pass: commit
+     * counts, first/last dates, classification (human / agent / bot), and
+     * per-contributor AI-assist stats from commit trailers. Replaces separate
+     * `git shortlog` and per-author date invocations.
+     */
+    private extractContributorsFromCommits(commits: any[]): any[] {
+        interface Aggregate {
+            name: string;
+            email: string;
+            commits: number;
+            firstCommit: string;
+            lastCommit: string;
+            authoredCommits: any[];
+        }
+        const authorMap = new Map<string, Aggregate>();
         for (const c of commits) {
             const key = c.author?.email ?? 'unknown';
             const existing = authorMap.get(key);
             if (existing) {
                 existing.commits++;
                 if (c.date > existing.lastCommit) { existing.lastCommit = c.date; }
+                if (c.date < existing.firstCommit) { existing.firstCommit = c.date; }
+                existing.authoredCommits.push(c);
             } else {
                 authorMap.set(key, {
                     name: c.author?.name ?? 'Unknown',
                     email: key,
                     commits: 1,
+                    firstCommit: c.date ?? new Date().toISOString(),
                     lastCommit: c.date ?? new Date().toISOString(),
+                    authoredCommits: [c],
                 });
             }
         }
-        return Array.from(authorMap.values()).sort((a, b) => b.commits - a.commits);
+
+        return Array.from(authorMap.values())
+            .map(({ authoredCommits, ...contributor }) => {
+                const classification = classifyContributor(contributor.name, contributor.email, authoredCommits);
+                return {
+                    ...contributor,
+                    additions: 0,
+                    deletions: 0,
+                    contributorKind: classification.kind,
+                    aiAssistRate: classification.aiAssistRate,
+                    agentName: classification.agentName,
+                };
+            })
+            .sort((a, b) => b.commits - a.commits);
     }
 
     private async analyzeFileExperts(fileData: any): Promise<Expert[]> {
         try {
-            const repositoryData = await this.gatherRepositoryData(fileData.repository || 'current', await this.assessRepositorySize());
+            const snapshot = await this.collectRepoSnapshot();
+            const repositoryData = this.gatherRepositoryData(fileData.repository || 'current', this.assessRepositorySize(snapshot), snapshot);
             
             const filePath = fileData.path || fileData.filePath;
             if (!filePath) {
@@ -931,7 +1135,12 @@ Respond with JSON only (NO markdown, NO explanations):
                     teamRole: contributor.commits > 10 ? 'Regular contributor' : 'Occasional contributor',
                     hiddenStrengths: ['Code review', 'Documentation'],
                     idealChallenges: ['Bug fixes', 'Feature development'],
-                    isBot: detectBotContributor(contributor.name, contributor.email)
+                    isBot: contributor.contributorKind
+                        ? contributor.contributorKind === 'ai-agent' || contributor.contributorKind === 'automation-bot'
+                        : detectBotContributor(contributor.name, contributor.email),
+                    contributorKind: contributor.contributorKind,
+                    aiAssistRate: contributor.aiAssistRate,
+                    agentName: contributor.agentName
                 }))
                 .sort((a: any, b: any) => b.contributions - a.contributions)
                 .slice(0, 5);
@@ -1296,12 +1505,14 @@ Respond with JSON only (NO markdown, NO explanations):
     }
 
     private mapFileExpertise(files: string[], experts: Expert[]): FileExpertise[] {
+        // changeFrequency 0 = not measured; per-file commit counts aren't
+        // fetched in this fallback path, and fabricated values mislead reports
         return files.map(file => ({
             fileName: file.split('/').pop() || file,
             filePath: file,
             experts: experts.slice(0, 2),
             lastModified: new Date(),
-            changeFrequency: Math.floor(Math.random() * 10) + 1
+            changeFrequency: 0
         }));
     }
 
@@ -1382,6 +1593,7 @@ Respond with JSON only (NO markdown, NO explanations):
             this.gitWorkerClient.dispose();
             this.gitWorkerClient = null;
         }
+        this.snapshotCache = null;
     }
 
     async saveAnalysis(analysis: ExpertiseAnalysis): Promise<void> {

--- a/src/core/expertise-webview.ts
+++ b/src/core/expertise-webview.ts
@@ -609,6 +609,7 @@ export class ExpertiseWebviewProvider {
             <span class="pill">Generated <strong>${this.safeFormatDate(analysis.generatedAt)}</strong></span>
             <span class="pill"><strong>${analysis.totalFiles}</strong> files scanned</span>
             <span class="pill"><strong>${analysis.expertProfiles.filter((e: any) => !e.isBot).length}</strong> humans · <strong>${analysis.expertProfiles.filter((e: any) => e.isBot).length}</strong> agents</span>
+            ${analysis.aiAttribution?.assistedCommits ? `<span class="pill">🤝 <strong>${Math.round(analysis.aiAttribution.assistedShare * 100)}%</strong> AI-assisted commits</span>` : ''}
         </div>
     </div>
 
@@ -619,7 +620,7 @@ export class ExpertiseWebviewProvider {
                 const barColor = expert.isBot ? '#374151' : (expert.expertise >= 20 ? '#06b6d4' : '#374151');
                 const cardClass = expert.isBot ? 'bot' : (expert.expertise >= 60 ? 'high' : expert.expertise < 20 ? 'low' : '');
                 return `<div class="expert-card ${cardClass}">
-                    <div class="expert-name">${expert.isBot ? '🤖 ' : ''}${expert.name}${expert.teamRole ? `<span class="role-badge">${expert.teamRole}</span>` : ''}</div>
+                    <div class="expert-name">${expert.isBot ? '🤖 ' : expert.contributorKind === 'ai-assisted-human' ? '🤝 ' : ''}${expert.name}${expert.teamRole ? `<span class="role-badge">${expert.teamRole}</span>` : ''}</div>
                     <div class="expert-email">${expert.email}</div>
                     <div class="bar-chart"><svg viewBox="0 0 400 24"><rect width="400" height="24" fill="#1e293b"/><rect width="${expert.expertise * 4}" height="24" fill="${barColor}"/><text x="${Math.max(expert.expertise * 4 - 8, 30)}" y="17" text-anchor="end" fill="#fff" font-size="12" font-weight="bold" font-family="sans-serif">${expert.expertise}%</text></svg></div>
                     <div class="expert-stats">
@@ -1152,6 +1153,7 @@ export class ExpertiseWebviewProvider {
             <span class="pill">Generated <strong>${this.safeFormatDate(analysis.generatedAt)}</strong></span>
             <span class="pill"><strong>${analysis.totalFiles}</strong> files scanned</span>
             <span class="pill"><strong>${analysis.expertProfiles.filter((e: any) => !e.isBot).length}</strong> humans · <strong>${analysis.expertProfiles.filter((e: any) => e.isBot).length}</strong> agents</span>
+            ${analysis.aiAttribution?.assistedCommits ? `<span class="pill">🤝 <strong>${Math.round(analysis.aiAttribution.assistedShare * 100)}%</strong> AI-assisted commits</span>` : ''}
             <span class="pill"><strong>${analysis.insights.length}</strong> insights</span>
         </div>
     </div>
@@ -1179,7 +1181,7 @@ export class ExpertiseWebviewProvider {
                 <tbody>
                     ${analysis.expertProfiles.map(expert => `
                     <tr data-name="${(expert.name || '').replace(/"/g, '&quot;')}" data-email="${(expert.email || '').replace(/"/g, '&quot;')}" data-expertise="${expert.expertise}" data-contributions="${expert.contributions}" data-lastcommit="${this.toSafeIsoDate(expert.lastCommit)}" data-specs="${(expert.specializations || []).join(', ')}">
-                        <td>${expert.isBot ? '🤖 ' : ''}${expert.name}${expert.teamRole ? ` <span class="role-badge">${expert.teamRole}</span>` : ''}</td>
+                        <td>${expert.isBot ? '🤖 ' : expert.contributorKind === 'ai-assisted-human' ? '🤝 ' : ''}${expert.name}${expert.teamRole ? ` <span class="role-badge">${expert.teamRole}</span>` : ''}</td>
                         <td class="email-cell">${expert.email}</td>
                         <td><div class="mini-bar"><div class="mini-bar-fill" style="width:${expert.expertise}%"></div></div> ${expert.expertise}%</td>
                         <td>${expert.contributions}</td>
@@ -1208,7 +1210,7 @@ export class ExpertiseWebviewProvider {
                                 </div>
                             </div>
                             <div class="expert-info">
-                                <h3>${expert.isBot ? '🤖 ' : ''}${expert.name}${expert.teamRole ? `<span class="role-badge">${expert.teamRole}</span>` : ''}</h3>
+                                <h3>${expert.isBot ? '🤖 ' : expert.contributorKind === 'ai-assisted-human' ? '🤝 ' : ''}${expert.name}${expert.teamRole ? `<span class="role-badge">${expert.teamRole}</span>` : ''}</h3>
                                 <div class="expert-email">${expert.email}</div>
                             </div>
                         </div>

--- a/src/core/git-service.ts
+++ b/src/core/git-service.ts
@@ -3,7 +3,13 @@ import { promisify } from 'util';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import type { GitCommit, GitContributor, GitAuthor } from '../types/expert';
+import type { GitCommit, GitContributor } from '../types/expert';
+import {
+    COMMIT_LOG_FORMAT,
+    COMMIT_LOG_FORMAT_WITH_FILES,
+    parseCommitLog,
+    parseCommitLogWithFiles
+} from '../utils/git-log-format';
 
 const execFileAsync = promisify(execFile);
 
@@ -88,72 +94,18 @@ export class GitService {
     }
 
     /**
-     * Parse git log output into GitCommit objects (DRY helper method)
-     * @param output - Raw git log output with format %H|%an|%ae|%ad|%s
-     * @returns Array of parsed GitCommit objects
+     * Parse git log output into GitCommit objects. The shared NUL-delimited
+     * format carries co-author and checkpoint trailers alongside the basics.
      */
     private parseCommitOutput(output: string): GitCommit[] {
-        return output
-            .split('\n')
-            .filter(line => line.trim())
-            .map(line => {
-                const parts = line.split('|');
-                if (parts.length >= 5) {
-                    const author: GitAuthor = {
-                        name: parts[1],
-                        email: parts[2]
-                    };
-                    const commit: GitCommit = {
-                        sha: parts[0],
-                        author: author,
-                        message: parts.slice(4).join('|'),
-                        date: parts[3],
-                        files: [] as string[]  // Files not fetched in basic log, would require --name-only
-                    };
-                    return commit;
-                }
-                return null;
-            })
-            .filter((commit): commit is GitCommit => commit !== null);
+        return parseCommitLog(output);
     }
 
     /**
      * Parse git log output where each commit is followed by a list of touched files.
      */
     private parseCommitOutputWithFiles(output: string): GitCommit[] {
-        return output
-            .split('__TEAMXRAY_COMMIT__')
-            .map(block => block.trim())
-            .filter(block => block.length > 0)
-            .map(block => {
-                const [metadataLine, ...fileLines] = block
-                    .split('\n')
-                    .map(line => line.trim())
-                    .filter(line => line.length > 0);
-
-                if (!metadataLine) {
-                    return null;
-                }
-
-                const parts = metadataLine.split('|');
-                if (parts.length < 5) {
-                    return null;
-                }
-
-                const author: GitAuthor = {
-                    name: parts[1],
-                    email: parts[2]
-                };
-
-                return {
-                    sha: parts[0],
-                    author,
-                    message: parts.slice(4).join('|'),
-                    date: parts[3],
-                    files: fileLines,
-                };
-            })
-            .filter((commit): commit is GitCommit => commit !== null);
+        return parseCommitLogWithFiles(output);
     }
 
     private normalizeGitPath(filePath: string): string {
@@ -172,8 +124,7 @@ export class GitService {
     async getCommits(limit: number = 500, sinceDate?: string): Promise<GitCommit[]> {
         const args = [
             'log',
-            '--pretty=format:%H|%an|%ae|%ad|%s',
-            '--date=iso',
+            `--pretty=format:${COMMIT_LOG_FORMAT}`,
             '-n',
             String(Math.max(1, Math.min(limit, 1000))) // Clamp between 1 and 1000
         ];
@@ -196,8 +147,7 @@ export class GitService {
         const args = [
             'log',
             `--author=${email}`,  // No quotes needed with execFile
-            '--pretty=format:%H|%an|%ae|%ad|%s',
-            '--date=iso',
+            `--pretty=format:${COMMIT_LOG_FORMAT}`,
             '-n',
             String(Math.max(1, Math.min(limit, 100)))
         ];
@@ -211,7 +161,9 @@ export class GitService {
      * @returns Array of contributors with commit counts
      */
     async getContributors(): Promise<GitContributor[]> {
-        const args = ['shortlog', '-sne', '--all'];
+        // HEAD (not --all): stays consistent with the commit history the
+        // analysis uses and avoids walking every remote ref on large repos
+        const args = ['shortlog', '-sne', 'HEAD'];
 
         const output = await this.executeGitCommand(args);
 
@@ -318,8 +270,7 @@ export class GitService {
         const args = [
             'log',
             `--since=${sinceDate}`,  // No quotes needed with execFile
-            '--pretty=format:%H|%an|%ae|%ad|%s',
-            '--date=iso',
+            `--pretty=format:${COMMIT_LOG_FORMAT}`,
             '-n',
             String(Math.max(1, Math.min(limit, 1000)))
         ];
@@ -340,8 +291,7 @@ export class GitService {
             'log',
             '--follow',
             '--name-only',
-            '--pretty=format:__TEAMXRAY_COMMIT__%n%H|%an|%ae|%ad|%s',
-            '--date=iso',
+            `--pretty=format:${COMMIT_LOG_FORMAT_WITH_FILES}`,
             '-n',
             String(Math.max(1, Math.min(limit, 1000))),
             '--',

--- a/src/core/git-worker-client.ts
+++ b/src/core/git-worker-client.ts
@@ -71,6 +71,10 @@ export class GitWorkerClient {
         return this.send({ type: 'getContributors', repoPath });
     }
 
+    async getHead(repoPath: string): Promise<string> {
+        return this.send({ type: 'getHead', repoPath });
+    }
+
     dispose(): void {
         if (this.worker) {
             this.worker.terminate();

--- a/src/core/git-worker.ts
+++ b/src/core/git-worker.ts
@@ -1,21 +1,21 @@
 /**
  * Worker thread for git operations — runs off the extension host thread.
- * Must NOT import 'vscode'. Only Node built-ins.
+ * Must NOT import 'vscode'. Only Node built-ins and vscode-free utils.
  */
 import { parentPort } from 'worker_threads';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { COMMIT_LOG_FORMAT, parseCommitLog } from '../utils/git-log-format';
 
 const execFileAsync = promisify(execFile);
 
 const GIT_TIMEOUT_MS = 30_000;
-const AUTHOR_DATE_TIMEOUT_MS = 5_000;
+const HEAD_TIMEOUT_MS = 5_000;
 const MAX_BUFFER = 10 * 1024 * 1024;
-const DATE_ENRICHMENT_LIMIT = 5;
 
 interface WorkerMessage {
     id: number;
-    type: 'getCommits' | 'getContributors';
+    type: 'getCommits' | 'getContributors' | 'getHead';
     repoPath: string;
     limit?: number;
     sinceDate?: string;
@@ -24,8 +24,7 @@ interface WorkerMessage {
 async function getCommits(repoPath: string, limit: number, sinceDate?: string) {
     const args = [
         'log',
-        '--pretty=format:%H|%an|%ae|%ad|%s',
-        '--date=iso',
+        `--pretty=format:${COMMIT_LOG_FORMAT}`,
         '-n',
         String(Math.max(1, Math.min(limit, 1000)))
     ];
@@ -38,31 +37,20 @@ async function getCommits(repoPath: string, limit: number, sinceDate?: string) {
         maxBuffer: MAX_BUFFER
     });
 
-    return stdout
-        .split('\n')
-        .filter(line => line.trim())
-        .map(line => {
-            const parts = line.split('|');
-            if (parts.length >= 5) {
-                return {
-                    sha: parts[0],
-                    author: { name: parts[1], email: parts[2] },
-                    message: parts.slice(4).join('|'),
-                    date: parts[3],
-                    files: [] as string[]
-                };
-            }
-            return null;
-        })
-        .filter(Boolean);
+    return parseCommitLog(stdout);
 }
 
+/**
+ * Contributor list via `git shortlog`. Kept as a fallback for repositories
+ * where the commit log comes back empty — the analyzer normally derives
+ * contributors (with first/last dates) from the commit list in one pass.
+ */
 async function getContributors(repoPath: string) {
     const { stdout } = await execFileAsync('git', [
-        'shortlog', '-sne', '--all'
+        'shortlog', '-sne', 'HEAD'
     ], { cwd: repoPath, timeout: GIT_TIMEOUT_MS, maxBuffer: MAX_BUFFER });
 
-    const contributors = stdout
+    return stdout
         .split('\n')
         .filter(line => line.trim())
         .map(line => {
@@ -82,25 +70,15 @@ async function getContributors(repoPath: string) {
         })
         .filter(Boolean)
         .sort((a: any, b: any) => b.commits - a.commits);
+}
 
-    // Get first/last commit dates for top contributors only to keep analysis responsive on large repos
-    for (const contrib of contributors.slice(0, DATE_ENRICHMENT_LIMIT) as any[]) {
-        try {
-            const { stdout: lastOut } = await execFileAsync('git', [
-                'log', `--author=${contrib.email}`, '--pretty=format:%ad', '--date=iso', '-n', '1'
-            ], { cwd: repoPath, timeout: AUTHOR_DATE_TIMEOUT_MS, maxBuffer: MAX_BUFFER });
-            contrib.lastCommit = lastOut.trim() || '';
-
-            const { stdout: firstOut } = await execFileAsync('git', [
-                'log', `--author=${contrib.email}`, '--pretty=format:%ad', '--date=iso', '--reverse', '-n', '1'
-            ], { cwd: repoPath, timeout: AUTHOR_DATE_TIMEOUT_MS, maxBuffer: MAX_BUFFER });
-            contrib.firstCommit = firstOut.trim() || '';
-        } catch {
-            // continue
-        }
-    }
-
-    return contributors;
+async function getHead(repoPath: string): Promise<string> {
+    const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], {
+        cwd: repoPath,
+        timeout: HEAD_TIMEOUT_MS,
+        maxBuffer: MAX_BUFFER
+    });
+    return stdout.trim();
 }
 
 if (parentPort) {
@@ -111,6 +89,8 @@ if (parentPort) {
                 result = await getCommits(msg.repoPath, msg.limit ?? 500, msg.sinceDate);
             } else if (msg.type === 'getContributors') {
                 result = await getContributors(msg.repoPath);
+            } else if (msg.type === 'getHead') {
+                result = await getHead(msg.repoPath);
             } else {
                 throw new Error(`Unknown message type: ${(msg as any).type}`);
             }

--- a/src/core/report-generator.ts
+++ b/src/core/report-generator.ts
@@ -157,6 +157,7 @@ export class ReportGenerator {
             <div>
                 <span class="pill">${analysis.totalFiles} files scanned</span>
                 <span class="pill">${analysis.expertProfiles.filter(e => !e.isBot).length} humans · ${analysis.expertProfiles.filter(e => e.isBot).length} agents</span>
+                ${analysis.aiAttribution?.assistedCommits ? `<span class="pill">🤝 ${Math.round(analysis.aiAttribution.assistedShare * 100)}% AI-assisted commits</span>` : ''}
                 <span class="pill">${windowLabel}</span>
             </div>
         </div>
@@ -172,7 +173,7 @@ export class ReportGenerator {
                     <div class="expert-card${glowClass}">
                         <div class="expert-top">
                             <div>
-                                <div class="expert-name">${expert.isBot ? '🤖 ' : ''}${expert.name}</div>
+                                <div class="expert-name">${expert.isBot ? '🤖 ' : expert.contributorKind === 'ai-assisted-human' ? '🤝 ' : ''}${expert.name}</div>
                                 <div class="expert-email mono">${expert.email}</div>
                             </div>
                             ${expert.teamRole ? `<span class="role-badge">${expert.teamRole}</span>` : ''}

--- a/src/core/repository-activity-service.ts
+++ b/src/core/repository-activity-service.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { ExpertiseAnalyzer } from './expertise-analyzer';
 import { Expert } from '../types/expert';
 import { GitService } from './git-service';
+import { classifyContributor } from '../utils/bot-detection';
 
 export interface GitHubRepository {
     owner: string;
@@ -96,7 +97,7 @@ export class RepositoryActivityService {
                 const recentCommits = commits.map(commit => ({
                     repo: 'Current Repository',
                     message: commit.message || 'No message',
-                    date: commit.date.split(' ')[0] || new Date().toISOString().split('T')[0],
+                    date: commit.date.split('T')[0] || new Date().toISOString().split('T')[0],
                     url: `#${commit.sha.substring(0, 7)}`,
                 }));
 
@@ -232,18 +233,24 @@ export class RepositoryActivityService {
             return Array.from(authorMap.values())
                 .sort((a, b) => b.commits - a.commits)
                 .slice(0, 5)
-                .map(a => ({
-                    name: a.name,
-                    email: a.email,
-                    expertise: Math.min(100, Math.round((a.commits / maxCommits) * 100)),
-                    contributions: a.commits,
-                    lastCommit: new Date(a.lastDate),
-                    specializations: this.inferSpecializationsFromFile(filePath),
-                    communicationStyle: 'Inferred from commit patterns',
-                    teamRole: a.commits > 10 ? 'Regular contributor' : 'Occasional contributor',
-                    hiddenStrengths: [],
-                    idealChallenges: [],
-                }));
+                .map(a => {
+                    const classification = classifyContributor(a.name, a.email);
+                    return {
+                        name: a.name,
+                        email: a.email,
+                        expertise: Math.min(100, Math.round((a.commits / maxCommits) * 100)),
+                        contributions: a.commits,
+                        lastCommit: new Date(a.lastDate),
+                        specializations: this.inferSpecializationsFromFile(filePath),
+                        communicationStyle: 'Inferred from commit patterns',
+                        teamRole: a.commits > 10 ? 'Regular contributor' : 'Occasional contributor',
+                        hiddenStrengths: [],
+                        idealChallenges: [],
+                        isBot: classification.kind === 'ai-agent' || classification.kind === 'automation-bot',
+                        contributorKind: classification.kind,
+                        agentName: classification.agentName,
+                    };
+                });
         } catch (error) {
             this.outputChannel.appendLine(`Error analyzing file experts: ${error}`);
             return null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { TokenManager } from './core/token-manager';
 import { ErrorHandler } from './utils/error-handler';
 import { ResourceManager } from './utils/resource-manager';
 import { Validator } from './utils/validation';
+import { setBotDetectionOptions } from './utils/bot-detection';
 
 // Module-level reference for cleanup in deactivate()
 let copilotService: CopilotService | undefined;
@@ -31,6 +32,25 @@ export function activate(context: vscode.ExtensionContext) {
     
     // Initialize the token manager
     const tokenManager = new TokenManager(context, outputChannel);
+
+    // Feed user-configured bot/agent detection patterns into the classifier,
+    // and keep them fresh when settings change
+    const applyBotDetectionConfig = () => {
+        const config = vscode.workspace.getConfiguration('teamxray');
+        setBotDetectionOptions({
+            additionalBotPatterns: config.get<string[]>('additionalBotPatterns', []),
+            humanOverrides: config.get<string[]>('humanOverrides', []),
+        });
+    };
+    applyBotDetectionConfig();
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('teamxray.additionalBotPatterns') ||
+                e.affectsConfiguration('teamxray.humanOverrides')) {
+                applyBotDetectionConfig();
+            }
+        })
+    );
     
     // Command to allow user to set their GitHub token
     context.subscriptions.push(

--- a/src/types/expert.ts
+++ b/src/types/expert.ts
@@ -13,6 +13,25 @@ export interface Expert {
     collaborationStyle?: 'independent' | 'collaborative' | 'mentoring';
     riskFactors?: string[];
     isBot?: boolean;
+    /** Finer-grained classification than isBot; 'ai-assisted-human' still counts as human */
+    contributorKind?: 'human' | 'ai-agent' | 'automation-bot' | 'ai-assisted-human';
+    /** Share (0-1) of this contributor's commits carrying agent-attribution signals */
+    aiAssistRate?: number;
+    /** Friendly name of the identified agent/bot, e.g. 'Claude Code', 'Dependabot' */
+    agentName?: string;
+}
+
+/** Repository-level AI attribution rollup derived from commit trailers */
+export interface AiAttributionSummary {
+    totalCommits: number;
+    /** Commits carrying agent signals (co-author trailers, checkpoints, aider marker) */
+    assistedCommits: number;
+    /** assistedCommits / totalCommits (0-1) */
+    assistedShare: number;
+    /** Assisted-commit counts per identified agent */
+    byAgent: Record<string, number>;
+    /** Commits authored directly by automation bots (Dependabot, Renovate, …) */
+    automationBotCommits: number;
 }
 
 export interface FileExpertise {
@@ -30,6 +49,12 @@ export interface GitCommit {
     message: string;
     date: string;
     files: string[];
+    /** Co-authored-by trailer identities (how most AI agents attribute their work) */
+    coAuthors?: GitAuthor[];
+    /** Checkpoint trailer id (Entire-Checkpoint) when session-capture tooling recorded this commit */
+    checkpointId?: string;
+    /** Attribution trailer value (Entire-Attribution) when present */
+    attribution?: string;
 }
 
 export interface GitAuthor {

--- a/src/utils/__tests__/bot-detection.test.ts
+++ b/src/utils/__tests__/bot-detection.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+    classifyContributor,
+    detectBotContributor,
+    detectCommitAgentSignals,
+    setBotDetectionOptions,
+} from '../bot-detection';
+import type { GitCommit } from '../../types/expert';
+
+function makeCommit(overrides: Partial<GitCommit> = {}): GitCommit {
+    return {
+        sha: 'abc123',
+        author: { name: 'Alice', email: 'alice@test.com' },
+        message: 'feat: add feature',
+        date: '2026-07-01T10:00:00+00:00',
+        files: [],
+        ...overrides,
+    };
+}
+
+afterEach(() => {
+    setBotDetectionOptions({});
+});
+
+describe('detectBotContributor (back-compat boolean)', () => {
+    it('flags GitHub App bot identities', () => {
+        expect(detectBotContributor('dependabot[bot]', '49699333+dependabot[bot]@users.noreply.github.com')).toBe(true);
+        expect(detectBotContributor('github-actions[bot]', '41898282+github-actions[bot]@users.noreply.github.com')).toBe(true);
+        expect(detectBotContributor('renovate[bot]', '29139614+renovate[bot]@users.noreply.github.com')).toBe(true);
+        expect(detectBotContributor('some-app[bot]', 'noreply@github.com')).toBe(true);
+    });
+
+    it('flags known agent mailboxes', () => {
+        expect(detectBotContributor('Claude', 'noreply@anthropic.com')).toBe(true);
+        expect(detectBotContributor('Claude', 'claude@users.noreply.github.com')).toBe(true);
+        expect(detectBotContributor('Substrate', 'bot@substrate.run')).toBe(true);
+    });
+
+    it('does not flag humans', () => {
+        expect(detectBotContributor('Alice', 'alice@test.com')).toBe(false);
+        expect(detectBotContributor('Andrea Griffiths', 'andrea@github.com')).toBe(false);
+        expect(detectBotContributor(undefined, undefined)).toBe(false);
+    });
+});
+
+describe('classifyContributor identity table', () => {
+    it.each([
+        ['Cursor Agent', 'cursoragent@cursor.com', 'Cursor'],
+        ['Cursor Agent', 'agent@cursor.com', 'Cursor'],
+        ['devin-ai-integration[bot]', 'devin-ai-integration@users.noreply.github.com', 'Devin'],
+        ['chatgpt-codex-connector[bot]', '12345+chatgpt-codex-connector[bot]@users.noreply.github.com', 'OpenAI Codex'],
+        ['google-labs-jules[bot]', '12345+google-labs-jules[bot]@users.noreply.github.com', 'Google Jules'],
+        ['amazon-q-developer[bot]', '12345+amazon-q-developer[bot]@users.noreply.github.com', 'Amazon Q'],
+        ['opencode', 'noreply@opencode.ai', 'OpenCode'],
+        ['openhands', 'openhands@all-hands.dev', 'OpenHands'],
+        ['aider', 'noreply@aider.chat', 'Aider'],
+        ['Copilot', '223556219+Copilot@users.noreply.github.com', 'GitHub Copilot'],
+        ['copilot-swe-agent[bot]', '198982749+copilot-swe-agent[bot]@users.noreply.github.com', 'GitHub Copilot'],
+    ])('classifies %s <%s> as ai-agent (%s)', (name, email, agentName) => {
+        const result = classifyContributor(name, email);
+        expect(result.kind).toBe('ai-agent');
+        expect(result.agentName).toBe(agentName);
+        expect(result.confidence).toBe('high');
+    });
+
+    it.each([
+        ['dependabot[bot]', '49699333+dependabot[bot]@users.noreply.github.com', 'Dependabot'],
+        ['renovate[bot]', '29139614+renovate[bot]@users.noreply.github.com', 'Renovate'],
+        ['github-actions', 'actions@github.com', 'GitHub Actions'],
+    ])('classifies %s as automation-bot (%s)', (name, email, agentName) => {
+        const result = classifyContributor(name, email);
+        expect(result.kind).toBe('automation-bot');
+        expect(result.agentName).toBe(agentName);
+    });
+
+    it('classifies unknown [bot] identities as automation-bot with medium confidence', () => {
+        const result = classifyContributor('some-future-tool[bot]', '999+some-future-tool[bot]@users.noreply.github.com');
+        expect(result.kind).toBe('automation-bot');
+        expect(result.confidence).toBe('medium');
+    });
+
+    it('classifies plain humans as human', () => {
+        const result = classifyContributor('Alice', 'alice@test.com');
+        expect(result.kind).toBe('human');
+        expect(result.agentName).toBeUndefined();
+    });
+});
+
+describe('classifyContributor options', () => {
+    it('honors additionalBotPatterns', () => {
+        const result = classifyContributor('deploy-bot', 'deploys@mycorp.com', undefined, {
+            additionalBotPatterns: ['deploys@mycorp.com'],
+        });
+        expect(result.kind).toBe('automation-bot');
+        expect(result.signals[0]).toContain('custom-pattern');
+    });
+
+    it('honors humanOverrides over identity matches', () => {
+        const result = classifyContributor('Cursor Agent', 'cursoragent@cursor.com', undefined, {
+            humanOverrides: ['cursoragent@cursor.com'],
+        });
+        expect(result.kind).toBe('human');
+    });
+
+    it('uses process-wide options set via setBotDetectionOptions', () => {
+        setBotDetectionOptions({ additionalBotPatterns: ['ci@internal.corp'] });
+        expect(classifyContributor('CI', 'ci@internal.corp').kind).toBe('automation-bot');
+    });
+});
+
+describe('detectCommitAgentSignals', () => {
+    it('detects agent co-authors', () => {
+        const commit = makeCommit({
+            coAuthors: [{ name: 'Claude', email: 'noreply@anthropic.com' }],
+        });
+        const result = detectCommitAgentSignals(commit);
+        expect(result.assisted).toBe(true);
+        expect(result.agents).toContain('Claude Code');
+    });
+
+    it('detects Copilot co-authors on human-authored commits', () => {
+        const commit = makeCommit({
+            coAuthors: [{ name: 'Copilot', email: '223556219+Copilot@users.noreply.github.com' }],
+        });
+        const result = detectCommitAgentSignals(commit);
+        expect(result.assisted).toBe(true);
+        expect(result.agents).toContain('GitHub Copilot');
+    });
+
+    it('detects checkpoint trailers', () => {
+        const result = detectCommitAgentSignals(makeCommit({ checkpointId: '8a513f56ed70' }));
+        expect(result.assisted).toBe(true);
+        expect(result.signals).toContain('checkpoint');
+    });
+
+    it('detects the aider subject marker', () => {
+        const result = detectCommitAgentSignals(makeCommit({ message: 'fix parser (aider)' }));
+        expect(result.assisted).toBe(true);
+        expect(result.agents).toContain('Aider');
+    });
+
+    it('reports human commits as unassisted', () => {
+        const result = detectCommitAgentSignals(makeCommit({ coAuthors: [{ name: 'Bob', email: 'bob@test.com' }] }));
+        expect(result.assisted).toBe(false);
+        expect(result.agents).toEqual([]);
+    });
+});
+
+describe('classifyContributor with commits (ai-assisted-human)', () => {
+    const claudeCoAuthor = { name: 'Claude', email: 'noreply@anthropic.com' };
+
+    it('upgrades a human with frequent agent co-authors to ai-assisted-human', () => {
+        const commits = [
+            makeCommit({ coAuthors: [claudeCoAuthor] }),
+            makeCommit({ coAuthors: [claudeCoAuthor] }),
+            makeCommit({}),
+            makeCommit({}),
+        ];
+        const result = classifyContributor('Alice', 'alice@test.com', commits);
+        expect(result.kind).toBe('ai-assisted-human');
+        expect(result.aiAssistRate).toBe(0.5);
+        expect(result.agentName).toContain('Claude Code');
+    });
+
+    it('keeps a mostly-solo human as human but reports the rate', () => {
+        const commits = [
+            makeCommit({ coAuthors: [claudeCoAuthor] }),
+            ...Array.from({ length: 9 }, () => makeCommit({})),
+        ];
+        const result = classifyContributor('Alice', 'alice@test.com', commits);
+        expect(result.kind).toBe('human');
+        expect(result.aiAssistRate).toBeCloseTo(0.1);
+    });
+
+    it('never downgrades an ai-assisted human to bot in detectBotContributor semantics', () => {
+        expect(detectBotContributor('Alice', 'alice@test.com')).toBe(false);
+    });
+});

--- a/src/utils/__tests__/git-log-format.test.ts
+++ b/src/utils/__tests__/git-log-format.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import {
+    COMMIT_LOG_FORMAT,
+    parseCoAuthorValue,
+    parseCommitLog,
+    parseCommitLogWithFiles,
+    COMMIT_BLOCK_SENTINEL,
+} from '../git-log-format';
+
+const NUL = '\x00';
+const RS = '\x1e';
+
+function record(fields: string[]): string {
+    return fields.join(NUL) + RS;
+}
+
+describe('parseCoAuthorValue', () => {
+    it('parses standard values', () => {
+        expect(parseCoAuthorValue('Claude <noreply@anthropic.com>')).toEqual({
+            name: 'Claude',
+            email: 'noreply@anthropic.com',
+        });
+    });
+
+    it('lowercases emails and trims whitespace', () => {
+        expect(parseCoAuthorValue('  Copilot  <175728472+Copilot@users.noreply.github.com> ')).toEqual({
+            name: 'Copilot',
+            email: '175728472+copilot@users.noreply.github.com',
+        });
+    });
+
+    it('returns null for malformed values', () => {
+        expect(parseCoAuthorValue('no email here')).toBeNull();
+        expect(parseCoAuthorValue('')).toBeNull();
+    });
+});
+
+describe('parseCommitLog', () => {
+    it('parses records with trailers', () => {
+        const output = record([
+            'a'.repeat(40),
+            'Alice',
+            'alice@test.com',
+            '2026-07-01T10:00:00+00:00',
+            'feat: something',
+            'Claude <noreply@anthropic.com>',
+            '8a513f56ed70',
+            'agent:80',
+        ]);
+        const commits = parseCommitLog(output);
+        expect(commits).toHaveLength(1);
+        expect(commits[0].author).toEqual({ name: 'Alice', email: 'alice@test.com' });
+        expect(commits[0].coAuthors).toEqual([{ name: 'Claude', email: 'noreply@anthropic.com' }]);
+        expect(commits[0].checkpointId).toBe('8a513f56ed70');
+        expect(commits[0].attribution).toBe('agent:80');
+    });
+
+    it('handles author names and subjects containing pipes and multiple co-authors', () => {
+        const output = record([
+            'b'.repeat(40),
+            'Weird | Name',
+            'weird@test.com',
+            '2026-07-01T10:00:00+00:00',
+            'fix: a | b | c',
+            'Claude <noreply@anthropic.com>;Copilot <1+Copilot@users.noreply.github.com>',
+            '',
+            '',
+        ]);
+        const commits = parseCommitLog(output);
+        expect(commits[0].author.name).toBe('Weird | Name');
+        expect(commits[0].message).toBe('fix: a | b | c');
+        expect(commits[0].coAuthors).toHaveLength(2);
+        expect(commits[0].checkpointId).toBeUndefined();
+    });
+
+    it('parses multiple newline-separated records', () => {
+        const output =
+            record(['a'.repeat(40), 'A', 'a@t.com', '2026-07-01T10:00:00+00:00', 'one', '', '', '']) +
+            '\n' +
+            record(['b'.repeat(40), 'B', 'b@t.com', '2026-07-02T10:00:00+00:00', 'two', '', '', '']);
+        expect(parseCommitLog(output)).toHaveLength(2);
+    });
+});
+
+describe('parseCommitLogWithFiles', () => {
+    it('associates file lists with their commit', () => {
+        const fields = ['c'.repeat(40), 'A', 'a@t.com', '2026-07-01T10:00:00+00:00', 'touch files', '', '', ''].join(NUL);
+        const output = `${COMMIT_BLOCK_SENTINEL}\n${fields}\nsrc/a.ts\nsrc/b.ts\n`;
+        const commits = parseCommitLogWithFiles(output);
+        expect(commits).toHaveLength(1);
+        expect(commits[0].files).toEqual(['src/a.ts', 'src/b.ts']);
+    });
+});
+
+describe('integration with real git', () => {
+    it('round-trips through an actual git log invocation', () => {
+        let output: string;
+        try {
+            output = execFileSync('git', ['log', `--pretty=format:${COMMIT_LOG_FORMAT}`, '-n', '5'], {
+                encoding: 'utf8',
+                timeout: 10_000,
+            });
+        } catch {
+            return; // not a git checkout (e.g. tarball CI) — nothing to verify
+        }
+        const commits = parseCommitLog(output);
+        expect(commits.length).toBeGreaterThan(0);
+        for (const commit of commits) {
+            expect(commit.sha).toMatch(/^[0-9a-f]{40}$/);
+            expect(commit.author.email).toContain('@');
+            expect(commit.date).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        }
+    });
+});

--- a/src/utils/bot-detection.ts
+++ b/src/utils/bot-detection.ts
@@ -1,40 +1,346 @@
 /**
- * Detect likely bot/agent contributors from git author metadata.
- * Covers common GitHub bot identities and known agent mailboxes.
+ * Contributor classification: humans, AI coding agents, automation bots,
+ * and AI-assisted humans.
+ *
+ * Detection uses two signal layers:
+ *  1. Author identity (name/email) against a declarative identity table.
+ *  2. Commit trailers — Co-authored-by lines and checkpoint/attribution
+ *     trailers — which is where most agent-assisted work is attributed,
+ *     since agents typically commit under the human's identity.
+ *
+ * Must NOT import 'vscode' (used by the worker-adjacent code paths and unit
+ * tests). Configuration is passed in via options or setBotDetectionOptions.
  */
-export function detectBotContributor(name?: string, email?: string): boolean {
+import type { GitCommit } from '../types/expert';
+
+export type ContributorKind = 'human' | 'ai-agent' | 'automation-bot' | 'ai-assisted-human';
+
+export interface ContributorClassification {
+    kind: ContributorKind;
+    confidence: 'high' | 'medium' | 'low';
+    /** Which rules fired, e.g. ['email:cursoragent@cursor.com', 'trailer:co-author:Claude Code'] */
+    signals: string[];
+    /** Friendly agent/bot name when identified, e.g. 'Claude Code', 'Dependabot' */
+    agentName?: string;
+    /** Share of this contributor's commits carrying agent signals (0-1), when commits were provided */
+    aiAssistRate?: number;
+}
+
+export interface BotDetectionOptions {
+    /** Extra case-insensitive substrings matched against "name <email>"; matches classify as automation-bot */
+    additionalBotPatterns?: string[];
+    /** Emails never classified as bot/agent, e.g. a human named "botten" tripping a pattern */
+    humanOverrides?: string[];
+}
+
+interface AgentIdentity {
+    agentName: string;
+    kind: 'ai-agent' | 'automation-bot';
+    /** Exact lowercased emails */
+    emails?: string[];
+    /** Email domain suffixes, matched against the part after '@' */
+    emailDomains?: string[];
+    /** Lowercased substrings matched anywhere in the email */
+    emailSubstrings?: string[];
+    /** Exact lowercased author names */
+    names?: string[];
+    /** Regexes tested against the lowercased email */
+    emailPatterns?: RegExp[];
+}
+
+/**
+ * Known agent/bot identities. Specific AI agents are listed before the
+ * generic [bot] rules so e.g. devin-ai-integration[bot] classifies as an
+ * AI agent, not a generic automation bot. Adding an agent is one entry here.
+ */
+const KNOWN_IDENTITIES: AgentIdentity[] = [
+    // ── AI coding agents ─────────────────────────────────────────────
+    {
+        agentName: 'Claude Code',
+        kind: 'ai-agent',
+        emailSubstrings: ['noreply@anthropic.com'],
+        emails: ['claude@users.noreply.github.com'],
+    },
+    {
+        agentName: 'GitHub Copilot',
+        kind: 'ai-agent',
+        names: ['copilot-swe-agent[bot]', 'copilot'],
+        emailPatterns: [/^\d+\+copilot(-swe-agent)?(\[bot\])?@users\.noreply\.github\.com$/],
+    },
+    {
+        agentName: 'Cursor',
+        kind: 'ai-agent',
+        names: ['cursor agent'],
+        emails: ['cursoragent@cursor.com', 'agent@cursor.com'],
+    },
+    {
+        agentName: 'Devin',
+        kind: 'ai-agent',
+        names: ['devin-ai-integration[bot]'],
+        emailSubstrings: ['devin-ai-integration'],
+    },
+    {
+        agentName: 'OpenAI Codex',
+        kind: 'ai-agent',
+        names: ['chatgpt-codex-connector[bot]'],
+        emailSubstrings: ['chatgpt-codex-connector'],
+    },
+    {
+        agentName: 'Google Jules',
+        kind: 'ai-agent',
+        names: ['google-labs-jules[bot]'],
+        emailSubstrings: ['google-labs-jules'],
+    },
+    {
+        agentName: 'Amazon Q',
+        kind: 'ai-agent',
+        names: ['amazon-q-developer[bot]'],
+        emailSubstrings: ['amazon-q-developer'],
+    },
+    {
+        agentName: 'OpenCode',
+        kind: 'ai-agent',
+        emails: ['noreply@opencode.ai'],
+        emailDomains: ['opencode.ai'],
+    },
+    {
+        agentName: 'OpenHands',
+        kind: 'ai-agent',
+        emails: ['openhands@all-hands.dev'],
+        emailDomains: ['all-hands.dev'],
+    },
+    {
+        agentName: 'Aider',
+        kind: 'ai-agent',
+        names: ['aider'],
+        emailDomains: ['aider.chat'],
+    },
+    {
+        agentName: 'Substrate',
+        kind: 'ai-agent',
+        emails: ['bot@substrate.run'],
+    },
+    // ── Automation bots ──────────────────────────────────────────────
+    {
+        agentName: 'Dependabot',
+        kind: 'automation-bot',
+        names: ['dependabot', 'dependabot[bot]'],
+        emailDomains: ['dependabot.com'],
+    },
+    {
+        agentName: 'Renovate',
+        kind: 'automation-bot',
+        names: ['renovate', 'renovate[bot]', 'renovate bot'],
+        emailDomains: ['renovateapp.com'],
+    },
+    {
+        agentName: 'GitHub Actions',
+        kind: 'automation-bot',
+        names: ['github-actions', 'github-actions[bot]'],
+        emails: ['actions@github.com'],
+    },
+];
+
+/** Threshold at which a human with agent-co-authored commits is surfaced as AI-assisted. */
+const AI_ASSIST_KIND_THRESHOLD = 0.25;
+const AI_ASSIST_MIN_COMMITS = 2;
+
+let defaultOptions: BotDetectionOptions = {};
+
+/**
+ * Set process-wide detection options (from workspace settings). Call sites
+ * that cannot thread options through can rely on this; explicit options
+ * passed to classifyContributor always win.
+ */
+export function setBotDetectionOptions(options: BotDetectionOptions): void {
+    defaultOptions = options ?? {};
+}
+
+function matchIdentity(lowerName: string, lowerEmail: string): { identity: AgentIdentity; signal: string } | null {
+    const emailDomain = lowerEmail.split('@')[1] ?? '';
+
+    for (const identity of KNOWN_IDENTITIES) {
+        if (identity.emails?.includes(lowerEmail)) {
+            return { identity, signal: `email:${lowerEmail}` };
+        }
+        if (identity.emailDomains?.some(d => emailDomain === d || emailDomain.endsWith(`.${d}`))) {
+            return { identity, signal: `email-domain:${emailDomain}` };
+        }
+        if (lowerEmail && identity.emailSubstrings?.some(s => lowerEmail.includes(s))) {
+            return { identity, signal: `email:${lowerEmail}` };
+        }
+        if (identity.emailPatterns?.some(p => p.test(lowerEmail))) {
+            return { identity, signal: `email:${lowerEmail}` };
+        }
+        if (lowerName && identity.names?.includes(lowerName)) {
+            return { identity, signal: `name:${lowerName}` };
+        }
+    }
+    return null;
+}
+
+function matchGenericBot(lowerName: string, lowerEmail: string): string | null {
+    if (lowerEmail.includes('[bot]@')) {
+        return `email:${lowerEmail}`;
+    }
+    if ((/^\d+\+.+\[bot\]@users\.noreply\.github\.com$/i).test(lowerEmail)) {
+        return `email:${lowerEmail}`;
+    }
+    if (lowerName.endsWith('[bot]')) {
+        return `name:${lowerName}`;
+    }
+    if (
+        (lowerEmail.includes('noreply@github.com') || lowerEmail.includes('@users.noreply.github.com')) &&
+        lowerName.includes('[bot]')
+    ) {
+        return `name:${lowerName}`;
+    }
+    return null;
+}
+
+export interface CommitAgentSignals {
+    /** True when the commit carries any agent-attribution signal */
+    assisted: boolean;
+    /** Friendly names of agents identified on the commit */
+    agents: string[];
+    /** Which signals fired, e.g. ['co-author:Claude Code', 'checkpoint'] */
+    signals: string[];
+}
+
+/**
+ * Inspect a single commit's trailers/subject for agent attribution:
+ * agent co-authors, checkpoint/attribution trailers, and the aider
+ * subject marker.
+ */
+export function detectCommitAgentSignals(commit: GitCommit): CommitAgentSignals {
+    const agents = new Set<string>();
+    const signals: string[] = [];
+
+    for (const coAuthor of commit.coAuthors ?? []) {
+        const match = matchIdentity(
+            (coAuthor.name ?? '').trim().toLowerCase(),
+            (coAuthor.email ?? '').trim().toLowerCase()
+        );
+        if (match) {
+            agents.add(match.identity.agentName);
+            signals.push(`co-author:${match.identity.agentName}`);
+        } else if (matchGenericBot(
+            (coAuthor.name ?? '').trim().toLowerCase(),
+            (coAuthor.email ?? '').trim().toLowerCase()
+        )) {
+            agents.add(coAuthor.name || 'Unknown agent');
+            signals.push(`co-author:${coAuthor.name}`);
+        }
+    }
+
+    if (commit.checkpointId) {
+        agents.add('Session-captured agent');
+        signals.push('checkpoint');
+    }
+    if (commit.attribution) {
+        signals.push('attribution');
+    }
+    if (/\(aider\)\s*$/i.test(commit.message ?? '')) {
+        agents.add('Aider');
+        signals.push('subject:aider');
+    }
+
+    return { assisted: signals.length > 0, agents: Array.from(agents), signals };
+}
+
+/**
+ * Classify a contributor from identity and (optionally) their commits.
+ * Without commits this is a pure name/email lookup; with commits, trailer
+ * signals can upgrade a human to 'ai-assisted-human' and compute their
+ * AI-assist rate.
+ */
+export function classifyContributor(
+    name?: string,
+    email?: string,
+    commits?: GitCommit[],
+    options?: BotDetectionOptions
+): ContributorClassification {
+    const opts = options ?? defaultOptions;
     const lowerName = (name ?? '').trim().toLowerCase();
     const lowerEmail = (email ?? '').trim().toLowerCase();
 
     if (!lowerName && !lowerEmail) {
-        return false;
+        return { kind: 'human', confidence: 'low', signals: [] };
     }
 
-    if (
-        lowerEmail.includes('[bot]@') ||
-        (/^\d+\+.+\[bot\]@users\.noreply\.github\.com$/i).test(lowerEmail) ||
-        (lowerEmail.includes('noreply@github.com') && lowerName.includes('[bot]')) ||
-        (lowerEmail.includes('@users.noreply.github.com') && lowerName.includes('[bot]'))
-    ) {
-        return true;
+    if (opts.humanOverrides?.some(o => o.trim().toLowerCase() === lowerEmail && lowerEmail)) {
+        return { kind: 'human', confidence: 'high', signals: [`override:${lowerEmail}`] };
     }
 
-    if (
-        lowerName.endsWith('[bot]') ||
-        lowerName === 'dependabot' ||
-        lowerName === 'renovate' ||
-        lowerName === 'github-actions'
-    ) {
-        return true;
+    const identityString = `${lowerName} <${lowerEmail}>`;
+    const customPattern = opts.additionalBotPatterns?.find(p => {
+        const pattern = p.trim().toLowerCase();
+        return pattern.length > 0 && identityString.includes(pattern);
+    });
+    if (customPattern) {
+        return {
+            kind: 'automation-bot',
+            confidence: 'high',
+            signals: [`custom-pattern:${customPattern}`],
+            agentName: name?.trim() || customPattern,
+        };
     }
 
-    if (
-        lowerEmail.includes('noreply@anthropic.com') ||
-        lowerEmail.includes('bot@substrate.run') ||
-        lowerEmail.includes('claude@users.noreply.github.com')
-    ) {
-        return true;
+    const identityMatch = matchIdentity(lowerName, lowerEmail);
+    if (identityMatch) {
+        return {
+            kind: identityMatch.identity.kind,
+            confidence: 'high',
+            signals: [identityMatch.signal],
+            agentName: identityMatch.identity.agentName,
+        };
     }
 
-    return false;
+    const genericSignal = matchGenericBot(lowerName, lowerEmail);
+    if (genericSignal) {
+        return {
+            kind: 'automation-bot',
+            confidence: 'medium',
+            signals: [genericSignal],
+            agentName: name?.trim() || undefined,
+        };
+    }
+
+    // Human — check commit trailers for AI assistance
+    if (commits && commits.length > 0) {
+        let assisted = 0;
+        const agentNames = new Set<string>();
+        const signals = new Set<string>();
+        for (const commit of commits) {
+            const commitSignals = detectCommitAgentSignals(commit);
+            if (commitSignals.assisted) {
+                assisted++;
+                commitSignals.agents.forEach(a => agentNames.add(a));
+                commitSignals.signals.forEach(s => signals.add(`trailer:${s}`));
+            }
+        }
+        const aiAssistRate = assisted / commits.length;
+        if (assisted >= AI_ASSIST_MIN_COMMITS && aiAssistRate >= AI_ASSIST_KIND_THRESHOLD) {
+            return {
+                kind: 'ai-assisted-human',
+                confidence: 'medium',
+                signals: Array.from(signals),
+                agentName: Array.from(agentNames).join(', ') || undefined,
+                aiAssistRate,
+            };
+        }
+        return { kind: 'human', confidence: 'high', signals: [], aiAssistRate };
+    }
+
+    return { kind: 'human', confidence: 'medium', signals: [] };
+}
+
+/**
+ * Detect likely bot/agent contributors from git author metadata.
+ * Back-compatible boolean wrapper over classifyContributor: AI-assisted
+ * humans are NOT bots — they stay in human-focused insights.
+ */
+export function detectBotContributor(name?: string, email?: string): boolean {
+    const kind = classifyContributor(name, email).kind;
+    return kind === 'ai-agent' || kind === 'automation-bot';
 }

--- a/src/utils/git-log-format.ts
+++ b/src/utils/git-log-format.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared git log format and parser used by both the extension host
+ * (GitService) and the worker thread (git-worker). Must NOT import 'vscode'.
+ *
+ * Records are NUL-delimited fields terminated by an ASCII Record Separator
+ * (0x1E), so author names or subjects containing '|' can never shift fields.
+ * Trailers are extracted by git itself via %(trailers:key=...), which keeps
+ * the transferred data small while exposing agent attribution signals:
+ * Co-authored-by lines and checkpoint/attribution trailers.
+ */
+
+export interface ParsedCoAuthor {
+    name: string;
+    email: string;
+}
+
+export interface ParsedCommit {
+    sha: string;
+    author: { name: string; email: string };
+    message: string;
+    date: string;
+    files: string[];
+    coAuthors: ParsedCoAuthor[];
+    checkpointId?: string;
+    attribution?: string;
+}
+
+const FIELD_SEP = '\x00';
+const RECORD_SEP = '\x1e';
+
+// %aN/%aE respect .mailmap so contributors with multiple identities merge;
+// %aI is strict ISO 8601. Trailer key matching is case-insensitive in git,
+// so this catches both "Co-authored-by" and "Co-Authored-By".
+export const COMMIT_LOG_FORMAT =
+    '%H%x00%aN%x00%aE%x00%aI%x00%s' +
+    '%x00%(trailers:key=Co-authored-by,unfold,valueonly,separator=%x3B)' +
+    '%x00%(trailers:key=Entire-Checkpoint,unfold,valueonly,separator=%x3B)' +
+    '%x00%(trailers:key=Entire-Attribution,unfold,valueonly,separator=%x3B)' +
+    '%x1e';
+
+// Variant for logs that append per-commit file lists (--name-only). Files
+// follow the metadata line inside each sentinel-delimited block.
+export const COMMIT_BLOCK_SENTINEL = '__TEAMXRAY_COMMIT__';
+export const COMMIT_LOG_FORMAT_WITH_FILES =
+    `${COMMIT_BLOCK_SENTINEL}%n` +
+    '%H%x00%aN%x00%aE%x00%aI%x00%s' +
+    '%x00%(trailers:key=Co-authored-by,unfold,valueonly,separator=%x3B)' +
+    '%x00%(trailers:key=Entire-Checkpoint,unfold,valueonly,separator=%x3B)' +
+    '%x00%(trailers:key=Entire-Attribution,unfold,valueonly,separator=%x3B)';
+
+/** Parse a "Name <email>" co-author value. Returns null for malformed values. */
+export function parseCoAuthorValue(value: string): ParsedCoAuthor | null {
+    const match = value.trim().match(/^(.*?)\s*<([^<>]+)>$/);
+    if (!match) {
+        return null;
+    }
+    return { name: match[1].trim(), email: match[2].trim().toLowerCase() };
+}
+
+function commitFromFields(fields: string[], files: string[]): ParsedCommit | null {
+    if (fields.length < 5 || !fields[0]) {
+        return null;
+    }
+
+    const coAuthors = (fields[5] ?? '')
+        .split(';')
+        .map(v => parseCoAuthorValue(v))
+        .filter((v): v is ParsedCoAuthor => v !== null);
+
+    const checkpointId = (fields[6] ?? '').split(';')[0].trim();
+    const attribution = (fields[7] ?? '').split(';')[0].trim();
+
+    return {
+        sha: fields[0],
+        author: { name: fields[1], email: fields[2] },
+        date: fields[3],
+        message: fields[4],
+        files,
+        coAuthors,
+        checkpointId: checkpointId || undefined,
+        attribution: attribution || undefined,
+    };
+}
+
+/** Parse output produced with COMMIT_LOG_FORMAT (no file lists). */
+export function parseCommitLog(output: string): ParsedCommit[] {
+    return output
+        .split(RECORD_SEP)
+        .map(record => record.replace(/^[\r\n]+/, ''))
+        .filter(record => record.length > 0)
+        .map(record => commitFromFields(record.split(FIELD_SEP), []))
+        .filter((commit): commit is ParsedCommit => commit !== null);
+}
+
+/** Parse output produced with COMMIT_LOG_FORMAT_WITH_FILES (--name-only). */
+export function parseCommitLogWithFiles(output: string): ParsedCommit[] {
+    return output
+        .split(COMMIT_BLOCK_SENTINEL)
+        .map(block => block.trim())
+        .filter(block => block.length > 0)
+        .map(block => {
+            const [metadataLine, ...fileLines] = block
+                .split('\n')
+                .map(line => line.trim())
+                .filter(line => line.length > 0);
+            if (!metadataLine) {
+                return null;
+            }
+            return commitFromFields(metadataLine.split(FIELD_SEP), fileLines);
+        })
+        .filter((commit): commit is ParsedCommit => commit !== null);
+}


### PR DESCRIPTION
## Summary

Implements the agent-detection and performance plan (`PLAN-AGENT-DETECTION-AND-PERFORMANCE.md`, included in this PR with rollout status). Core insight: agent attribution lives in commit **trailers**, not author fields — most agent-assisted work is committed under the human's identity with a `Co-authored-by` line, which the previous detector never saw. On this repo's own history, 40 of the last 50 commits carry agent co-author trailers that were previously invisible.

## Detection

- New shared NUL-delimited `git log` format extracts `Co-authored-by` and checkpoint/attribution trailers in the same git invocation; respects `.mailmap` (`%aN`/`%aE`) and is immune to `|` in author names/subjects
- `bot-detection.ts` rebuilt around `classifyContributor()` with four kinds — `human` / `ai-agent` / `automation-bot` / `ai-assisted-human` — backed by a declarative identity table (Claude Code, Copilot, Cursor, Devin, Codex, Jules, Amazon Q, OpenCode, OpenHands, Aider, Dependabot, Renovate, GitHub Actions)
- Humans with frequent agent co-authors classify as `ai-assisted-human` (🤝 badge) and **stay** in all human-focused insights; the boolean `detectBotContributor()` remains as a back-compat wrapper
- New settings: `teamxray.additionalBotPatterns`, `teamxray.humanOverrides`
- Repo-level AI attribution (assisted share, per-agent breakdown) computed from trailers, shown as a header pill in webview + HTML report, and fed into the AI prompt

## Performance

- Files/commits/contributors collected **once** per analysis instead of twice, with files and commits fetched in parallel
- Contributors (incl. first/last dates and AI-assist rates) derived from the commit list in one in-memory pass — replaces `git shortlog --all` plus up to 10 per-author date invocations
- Snapshot cached keyed on HEAD + history window: repeat commands cost a single `git rev-parse`
- Bot-aware sampling: automation bots aggregate to a one-line prompt summary instead of occupying top contributor slots and prompt tokens
- Phase timing logs (`⏱ snapshot · sampling · ai`) in the output channel

## Bug fixes

- `findExpertForFile` filtered a commit list that never contains file paths, so the Copilot file-expert path always received zero commits — now uses `getCommitsForFile` (`--follow`)
- File expertise `changeFrequency` was `Math.random()` — removed
- File-expert fallback path never set `isBot`
- `sampleCommits` no longer mutates its input array

## Test plan

- [x] 67 tests pass (29 existing + 38 new, incl. a real-git round-trip integration test)
- [x] `npm run lint` — 0 errors (warning count unchanged from main)
- [x] `npm run compile` — both webpack bundles build; worker bundle verified to include the shared parser
- [x] Built `dist/git-worker.js` smoke-tested in a real `worker_threads` context against this repo (commits + co-authors + HEAD + contributor fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKnbnCfS9UbKRbErrzawBt

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKnbnCfS9UbKRbErrzawBt)_