### PR TITLE
Release Team X-Ray v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.2] - 2026-07-21
+
+### Dependencies
+- Updated Axios to 1.18.0.
+
 ## [2.1.1] - 2026-07-16
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teamxray",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teamxray",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "teamxray",
   "displayName": "Team X-Ray",
   "description": "Human discovery through code analysis - reveal team expertise, communication styles, and hidden strengths using the Copilot SDK and git history",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "publisher": "AndreaGriffiths",
   "author": {
     "name": "alacolombiadev"


### PR DESCRIPTION
## Summary
- Update Axios to 1.18.0.
- Prepare the Team X-Ray v2.1.2 Marketplace release.

## Validation
- `npm test`
- `npm audit --omit=dev --audit-level critical`
- `npm exec -- vsce package`
- Copilot SDK native ESM import check
