### PR TITLE
docs: add scoped directory-level AGENTS.md files

### DIFF
--- a/evals/AGENTS.md
+++ b/evals/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md — evals/
+
+Rules for evaluation files. Evals test real analysis quality — treat them like production.
+
+## Constraints
+
+- **Never mock real git data** — use actual fixture repos or recorded git output
+- Evals measure analysis quality, not code correctness — don't write evals that just check if functions run without throwing
+- `evalite` is the test harness — don't add a second eval framework
+
+## Adding Evals
+
+- New evals go in files named `*.eval.ts`
+- Each eval needs a clear scoring criterion — what does "good" look like for this analysis?
+- If an eval requires a real GitHub token, mark it with a `// requires: GITHUB_TOKEN` comment at the top so CI can skip it correctly

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md — src/
+
+Rules for all TypeScript source in this directory.
+
+## Language & Style
+
+- TypeScript strict mode — no `any`, no type assertions without a comment explaining why
+- No inline styles in webview components — CSP blocks them and they will silently fail
+- All VS Code API calls must handle the case where the extension is not yet activated
+
+## Testing
+
+- Every new function in `core/` or `utils/` needs a corresponding test in `__tests__/`
+- Target 80% coverage per file — CI enforces this, don't open a PR below it
+- Use real fixture data for tests, not mocked git output (see `evals/` for examples)
+
+## What NOT to Do
+
+- Don't import from `vscode` in `core/` or `utils/` — those modules must stay testable outside the extension host
+- Don't add `console.log` — use the extension's output channel via `error-handler.ts`
+- Don't hardcode paths — use `vscode.Uri` and `path.join`

--- a/src/core/AGENTS.md
+++ b/src/core/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md — src/core/
+
+Rules for the core analysis engine. This is the most sensitive part of the codebase — changes here affect every analysis result.
+
+## Custom Copilot SDK Tools
+
+- All tools must be **stateless** — the agent calls them multiple times per analysis session
+- Tools must be **read-only** — never write to disk, never mutate extension state
+- Tool responses must be serializable JSON — no class instances, no circular refs
+
+## Testing
+
+- Every function that processes git data needs a test in `__tests__/`
+- **80% coverage is required** — CI blocks PRs below this threshold, don't open one
+- Use real fixture data from actual git repos, not hand-crafted mocks that can't catch real edge cases
+- `copilot-service.ts` tests must cover the fallback chain: Copilot SDK → GitHub Models → local git-only
+
+## Worker Threads
+
+- Git parsing happens in `git-worker.ts` via worker threads — keep it that way
+- Don't move heavy git operations into the main thread; it blocks the VS Code UI
+- Worker communication is message-passing only — no shared state
+
+## What NOT to Do
+
+- Don't bypass `CopilotService` for AI calls — it's the single entry point for all AI providers
+- Don't add tools that write or mutate state — read-only is a hard constraint
+- Don't hardcode `maxCommits` — it's user-configurable for large repos

--- a/src/types/AGENTS.md
+++ b/src/types/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md — src/types/
+
+Rules for shared type definitions.
+
+## Constraints
+
+- Types here are imported across the entire extension — breaking changes affect everything
+- No runtime code in this directory — types and interfaces only
+- Don't use `any` — if you need an escape hatch, use `unknown` and narrow it at the call site
+- Prefer narrow types over wide ones — `'copilot' | 'github-models' | 'byok'` over `string`
+
+## Adding Types
+
+- New types go in the most specific file (`expert.ts` for expertise data, `management-insights.ts` for insights)
+- If a type is used in exactly one file, define it there instead — don't centralize prematurely

--- a/src/utils/AGENTS.md
+++ b/src/utils/AGENTS.md
@@ -13,7 +13,7 @@ Rules for utility modules. These are shared across the extension — keep them n
 
 - All errors surface through this module — don't use `console.log` or `console.error` anywhere in `src/`
 - User-facing messages must be plain English, no stack traces
-- Log full error details to the extension output channel for debugging
+- Log full error details to the extension output channel for debugging — always redact tokens, API keys, and any value sourced from credentials or secrets before logging
 
 ## Testing
 

--- a/src/utils/AGENTS.md
+++ b/src/utils/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md — src/utils/
+
+Rules for utility modules. These are shared across the extension — keep them narrow and side-effect free.
+
+## Bot Detection (`bot-detection.ts`)
+
+- Detection is **deterministic regex only** — never use LLM inference to classify bots
+- Adding a new bot pattern requires a corresponding test in `__tests__/bot-detection.test.ts`
+- Patterns match on email and/or display name — document which field each pattern targets
+- False positives (human flagged as bot) are worse than false negatives — err on the side of inclusion
+
+## Error Handling (`error-handler.ts`)
+
+- All errors surface through this module — don't use `console.log` or `console.error` anywhere in `src/`
+- User-facing messages must be plain English, no stack traces
+- Log full error details to the extension output channel for debugging
+
+## Testing
+
+- Every util function needs a test in `__tests__/`
+- Tests must not import from `vscode` — utils must be testable in plain Node.js


### PR DESCRIPTION
## What

Adds directory-level `AGENTS.md` files so rules live next to the code they govern, not three folders up in a monolithic root file.

## Why

A single root `AGENTS.md` works fine for humans browsing the repo. It doesn't work well for agents — they read what's in front of them at the directory level they're working in. A rule like "tools must be stateless" is most useful when it's in `src/core/`, not buried in a 200-line root file the agent may not load before picking a tool.

This is the same pattern Nicholas Tindle landed on at AutoGPT (documented [here](https://github.blog/open-source/maintainers/your-contributors-are-ai-first-now-is-your-project/)).

## Files added

- `src/AGENTS.md` — TypeScript rules, no inline styles, no vscode imports in core/utils
- `src/core/AGENTS.md` — stateless tools, worker thread rules, 80% coverage gate
- `src/utils/AGENTS.md` — bot detection is regex-only, never LLM inference  
- `src/types/AGENTS.md` — types only, no runtime code, prefer narrow types
- `evals/AGENTS.md` — never mock real git data, evalite only

Root `AGENTS.md` stays as the high-level overview — no changes there.